### PR TITLE
linux: ns: get_process_nspid() support old kernels

### DIFF
--- a/enable_hook.sh
+++ b/enable_hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-ln -s "../../lint.sh" "$(git rev-parse --show-toplevel)/.git/hooks/pre-commit"
+ln -s "$(git rev-parse --show-toplevel)/lint.sh" "$(git rev-parse --git-path hooks)/pre-commit"

--- a/granulate_utils/exceptions.py
+++ b/granulate_utils/exceptions.py
@@ -1,4 +1,4 @@
 class UnsupportedNamespaceError(Exception):
     def __init__(self, nstype: str):
-        super().__init__(f"Namespace '{nstype}' is not supported by this kernel")
+        super().__init__(f"Namespace {nstype!r} is not supported by this kernel")
         self.nstype = nstype

--- a/granulate_utils/exceptions.py
+++ b/granulate_utils/exceptions.py
@@ -1,0 +1,4 @@
+class UnsupportedNamespaceError(Exception):
+    def __init__(self, nstype: str):
+        super().__init__(f"Namespace '{nstype}' is not supported by this kernel")
+        self.nstype = nstype

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -100,7 +100,7 @@ def _get_process_nspid_by_sched_files(pid: int):
                 sched_file_path = procfs_child / "sched"
                 with sched_file_path.open("r") as sched_file:
                     sched_header_line = sched_file.readline()  # The first line contains the outer PID
-            except FileNotFoundError:
+            except (FileNotFoundError, ProcessLookupError):
                 # That's OK, processes might disappear before we get the chance to handle them
                 continue
 

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -143,7 +143,7 @@ def _get_process_nspid_by_sched_files(process: Process) -> int:
 
         return inner_pid
 
-    # If we weren't able to find the process' nspid, he must have been killed while searching (we only search
+    # If we weren't able to find the process' nspid, it must have been killed while searching (we only search
     # `/proc/pid/sched` files, and they exist as long as the process is running (including zombie processes)
     assert not process.is_running(), f"Process {process.pid} is running, but we failed to find his nspid"
 

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -88,7 +88,7 @@ def _get_process_nspid_by_sched_files(pid: int):
     # (fixed in 4.14) the outer PID is exposed, so we can find the target process by comparing the outer PID
 
     def _find_inner_pid() -> Optional[int]:
-        pattern = re.compile(r"\((\d+), #threads: ")
+        pattern = re.compile(r"\((\d+), #threads: ")  # Match example: "java (12329, #threads: 11)"
 
         procfs = Path("/proc")
         for process_dir in procfs.iterdir():

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -141,7 +141,8 @@ def _get_process_nspid_by_sched_files(process: Process) -> int:
 
         return inner_pid
 
-    # If we weren't able to find the process' nspid, he must have been killed while searching
+    # If we weren't able to find the process' nspid, he must have been killed while searching (we only search
+    # `/proc/pid/sched` files, and they exist as long as the process is running (including zombie processes)
     assert not process.is_running(), f"Process {process.pid} is running, but we failed to find his nspid"
 
     raise NoSuchProcess(process.pid)

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -97,13 +97,15 @@ def _get_process_nspid_by_sched_files(pid: int):
                 continue
 
             try:
-                sched_file = process_dir / "sched"
-                sched_contents = sched_file.open("r").readline()
-                match = pattern.search(sched_contents)
-                if match:
-                    outer_pid = int(match.group(1))
-                    if outer_pid == pid:
-                        return int(process_dir.name)
+                sched_file_path = process_dir / "sched"
+                with sched_file_path.open("r") as sched_file:
+                    sched_contents = sched_file.readline()  # The first line contains the outer PID
+
+                    match = pattern.search(sched_contents)
+                    if match:
+                        outer_pid = int(match.group(1))
+                        if outer_pid == pid:
+                            return int(process_dir.name)
             except FileNotFoundError:
                 # That's OK, processes might disappear before we get the chance to handle them
                 continue

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -90,15 +90,15 @@ def _get_process_nspid_by_sched_files(pid: int):
     def _find_inner_pid() -> Optional[int]:
         pattern = re.compile(r"\((\d+), #threads: ")
 
-        procfs = Path('/proc')
+        procfs = Path("/proc")
         for process_dir in procfs.iterdir():
             is_process_dir = process_dir.is_dir() and process_dir.name.isdigit()
             if not is_process_dir:
                 continue
 
             try:
-                sched_file = process_dir / 'sched'
-                sched_contents = sched_file.open('r').readline()
+                sched_file = process_dir / "sched"
+                sched_contents = sched_file.open("r").readline()
                 match = pattern.search(sched_contents)
                 if match:
                     outer_pid = int(match.group(1))
@@ -111,7 +111,7 @@ def _get_process_nspid_by_sched_files(pid: int):
         return None
 
     # We're searching `/proc`, so we only need to set our mount namespace
-    inner_pid = run_in_ns(['mnt'], _find_inner_pid, pid)
+    inner_pid = run_in_ns(["mnt"], _find_inner_pid, pid)
     return inner_pid
 
 

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -102,7 +102,7 @@ def _get_process_nspid_by_sched_files(pid: int):
                     sched_contents = sched_file.readline()  # The first line contains the outer PID
 
                     match = pattern.search(sched_contents)
-                    if match:
+                    if match is not None:
                         outer_pid = int(match.group(1))
                         if outer_pid == pid:
                             return int(process_dir.name)

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -99,12 +99,12 @@ def _get_process_nspid_by_sched_files(pid: int):
             try:
                 sched_file_path = procfs_child / "sched"
                 with sched_file_path.open("r") as sched_file:
-                    sched_contents = sched_file.readline()  # The first line contains the outer PID
+                    sched_header_line = sched_file.readline()  # The first line contains the outer PID
             except FileNotFoundError:
                 # That's OK, processes might disappear before we get the chance to handle them
                 continue
 
-            match = pattern.search(sched_contents)
+            match = pattern.search(sched_header_line)
             if match is not None:
                 outer_pid = int(match.group(1))
                 if outer_pid == pid:

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -159,13 +159,13 @@ def is_same_ns(process: Union[Process, int], nstype: str, process2: Union[Proces
         process2 = Process()  # `self`
 
     try:
-        return get_process_ns_inode(process, nstype) == get_process_ns_inode(process2, nstype)
+        return _get_process_ns_inode(process, nstype) == _get_process_ns_inode(process2, nstype)
     except UnsupportedNamespaceError:
         # The namespace does not exist in this kernel, hence the two processes are logically in the same namespace
         return True
 
 
-def get_process_ns_inode(process: Process, nstype: str):
+def _get_process_ns_inode(process: Process, nstype: str):
     try:
         ns_inode = os.stat(f"/proc/{process.pid}/ns/{nstype}").st_ino
     except FileNotFoundError as e:

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -91,13 +91,13 @@ def _get_process_nspid_by_sched_files(pid: int):
         pattern = re.compile(r"\((\d+), #threads: ")  # Match example: "java (12329, #threads: 11)"
 
         procfs = Path("/proc")
-        for process_dir in procfs.iterdir():
-            is_process_dir = process_dir.is_dir() and process_dir.name.isdigit()
+        for procfs_child in procfs.iterdir():
+            is_process_dir = procfs_child.is_dir() and procfs_child.name.isdigit()
             if not is_process_dir:
                 continue
 
             try:
-                sched_file_path = process_dir / "sched"
+                sched_file_path = procfs_child / "sched"
                 with sched_file_path.open("r") as sched_file:
                     sched_contents = sched_file.readline()  # The first line contains the outer PID
             except FileNotFoundError:
@@ -108,7 +108,7 @@ def _get_process_nspid_by_sched_files(pid: int):
             if match is not None:
                 outer_pid = int(match.group(1))
                 if outer_pid == pid:
-                    return int(process_dir.name)
+                    return int(procfs_child.name)
 
         return None
 

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -132,13 +132,13 @@ def _get_process_nspid_by_sched_files(pid: int) -> int:
         return inner_pid
 
     # If we weren't able to find the process' nspid, he must have been killed while searching
-    assert not Path(f'/proc/{pid}').exists(), f"Process {pid} is running, but we failed to find his nspid"
+    assert not Path(f"/proc/{pid}").exists(), f"Process {pid} is running, but we failed to find his nspid"
 
     raise NoSuchProcess(pid)
 
 
 def is_same_ns(pid: int, nstype: str, pid2: int = None) -> bool:
-    return get_process_ns_inode(pid2 if pid2 is not None else 'self', nstype) == get_process_ns_inode(pid, nstype)
+    return get_process_ns_inode(pid2 if pid2 is not None else "self", nstype) == get_process_ns_inode(pid, nstype)
 
 
 def get_process_ns_inode(pid: Union[int, str], nstype: str):

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -100,15 +100,15 @@ def _get_process_nspid_by_sched_files(pid: int):
                 sched_file_path = process_dir / "sched"
                 with sched_file_path.open("r") as sched_file:
                     sched_contents = sched_file.readline()  # The first line contains the outer PID
-
-                    match = pattern.search(sched_contents)
-                    if match is not None:
-                        outer_pid = int(match.group(1))
-                        if outer_pid == pid:
-                            return int(process_dir.name)
             except FileNotFoundError:
                 # That's OK, processes might disappear before we get the chance to handle them
                 continue
+
+            match = pattern.search(sched_contents)
+            if match is not None:
+                outer_pid = int(match.group(1))
+                if outer_pid == pid:
+                    return int(process_dir.name)
 
         return None
 

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -67,6 +67,20 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
     return path
 
 
+def get_process_nspid(pid: int) -> Optional[int]:
+    with open(f"/proc/{pid}/status") as f:
+        for line in f:
+            fields = line.split()
+            if fields[0] == "NSpid:":
+                return int(fields[-1])
+
+    # old kernel (pre 4.1) with no NSpid.
+    # TODO if needed, this can be implemented for pre 4.1, by reading all /proc/pid/sched files as
+    # seen by the PID NS; they expose the init NS PID (due to a bug fixed in 4.14~), and we can get the NS PID
+    # from the listing of those files itself.
+    return None
+
+
 def is_same_ns(pid: int, nstype: str, pid2: int = None) -> bool:
     return (
         os.stat(f"/proc/{pid2 if pid2 is not None else 'self'}/ns/{nstype}").st_ino


### PR DESCRIPTION
Make `get_process_nspid()` work with old kernels

Tested on Ubuntu 14.04 `3.13.0-170-generic`