### PR TITLE
Move get container id to utils

### DIFF
--- a/granulate_utils/linux/containers.py
+++ b/granulate_utils/linux/containers.py
@@ -1,0 +1,36 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+
+import re
+from typing import Optional, Union
+from psutil import Process, NoSuchProcess
+from pathlib import Path
+
+
+# ECS uses /ecs/uuid/container-id
+# standard Docker uses /docker/container-id
+# k8s uses /kubepods/{burstable,besteffort}/uuid/container-id
+# there are some variations to the above formats, but generally, the container
+# ID is always 64-hex digits.
+CONTAINER_ID_PATTERN = re.compile(r"[a-f0-9]{64}")
+
+
+def get_process_container_id(process: Union[int, Process]) -> Optional[str]:
+    """
+    Gets the container ID of a running process, or None if not in a container.
+    :raises NoSuchProcess: If the process doesn't or no longer exists
+    """
+    pid = process if isinstance(process, int) else process.pid
+    try:
+        cgroup = Path(f"/proc/{pid}/cgroup").read_text()
+    except FileNotFoundError:
+        raise NoSuchProcess(pid)
+
+    for line in cgroup.splitlines():
+        found = CONTAINER_ID_PATTERN.findall(line)
+        if found:
+            return found[-1]
+
+    return None

--- a/granulate_utils/linux/containers.py
+++ b/granulate_utils/linux/containers.py
@@ -4,10 +4,10 @@
 #
 
 import re
-from typing import Optional, Union
-from psutil import Process, NoSuchProcess
 from pathlib import Path
+from typing import Optional, Union
 
+from psutil import NoSuchProcess, Process
 
 # ECS uses /ecs/uuid/container-id
 # standard Docker uses /docker/container-id

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -14,6 +14,7 @@ from typing import Callable, List, Optional, TypeVar, Union
 from psutil import NoSuchProcess, Process, process_iter
 
 from granulate_utils.exceptions import UnsupportedNamespaceError
+from granulate_utils.linux.containers import get_process_container_id
 
 T = TypeVar("T")
 
@@ -293,7 +294,7 @@ def get_host_pid(nspid: int, container_id: str) -> Optional[int]:
     # Get the pid namespace of the given container
     for process in running_processes:
         try:
-            if container_id in Path(f"/proc/{process.pid}/cgroup").read_text():
+            if container_id == get_process_container_id(process):
                 pid_namespace = os.readlink(f"/proc/{process.pid}/ns/pid")
                 break
         except (FileNotFoundError, NoSuchProcess):


### PR DESCRIPTION
Based on (and fixes some of) https://github.com/Granulate/granulate-utils/pull/24

Matching gProfiler PR: https://github.com/Granulate/gprofiler/pull/278

Improved the function a bit along the way.