### PR TITLE
proc_events: bind() in init net NS

### DIFF
--- a/granulate_utils/linux/proc_events.py
+++ b/granulate_utils/linux/proc_events.py
@@ -203,8 +203,7 @@ class _ProcEventsListener(threading.Thread):
         # We make these initializations here (and not in the new thread) so if an exception occures it'll be
         # visible in the calling thread
         try:
-            # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
-            run_in_ns(["net"], lambda: self._socket.bind((0, self._CN_IDX_PROC)))
+            self._socket.bind((0, self._CN_IDX_PROC))
             self._register_for_connector_events(self._socket)
         except PermissionError as e:
             raise PermissionError(
@@ -240,6 +239,12 @@ _proc_events_listener: Optional[_ProcEventsListener] = None
 _listener_creation_lock = threading.Lock()
 
 
+def _start_listener():
+    listener = _ProcEventsListener()
+    listener.start()
+    return listener
+
+
 def _ensure_thread_started(func: Callable):
     def wrapper(*args, **kwargs):
         global _proc_events_listener
@@ -247,8 +252,8 @@ def _ensure_thread_started(func: Callable):
         with _listener_creation_lock:
             if _proc_events_listener is None:
                 try:
-                    _proc_events_listener = _ProcEventsListener()
-                    _proc_events_listener.start()
+                    # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
+                    _proc_events_listener = run_in_ns(["net"], _start_listener)
                 except Exception:
                     # TODO: We leak the pipe FDs here...
                     _proc_events_listener = None


### PR DESCRIPTION
Moved from gProfiler's `java.py`. This should be here as it is required from all users of `proc_events`, not solely `java.py`.

gProfiler PR: https://github.com/Granulate/gprofiler/pull/280