### PR TITLE
linux: Add get_cgroups helper

### DIFF
--- a/granulate_utils/exceptions.py
+++ b/granulate_utils/exceptions.py
@@ -3,6 +3,7 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
+
 class UnsupportedNamespaceError(Exception):
     def __init__(self, nstype: str):
         super().__init__(f"Namespace {nstype!r} is not supported by this kernel")

--- a/granulate_utils/exceptions.py
+++ b/granulate_utils/exceptions.py
@@ -1,3 +1,8 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+
 class UnsupportedNamespaceError(Exception):
     def __init__(self, nstype: str):
         super().__init__(f"Namespace {nstype!r} is not supported by this kernel")

--- a/granulate_utils/linux/cgroups.py
+++ b/granulate_utils/linux/cgroups.py
@@ -11,9 +11,10 @@ def get_cgroups(pid: int) -> List[Tuple[str, List[str], str]]:
     """
     Get the cgroups of a process in [(hier id., controllers, path)] parsed form.
     """
+
     def parse_line(line: str) -> Tuple[str, List[str], str]:
-        hier_id, controller_list, cgroup_path = line.split(':', maxsplit=2)
-        return hier_id, controller_list.split(','), cgroup_path
+        hier_id, controller_list, cgroup_path = line.split(":", maxsplit=2)
+        return hier_id, controller_list.split(","), cgroup_path
 
     try:
         text = Path(f"/proc/{pid}/cgroup").read_text()

--- a/granulate_utils/linux/cgroups.py
+++ b/granulate_utils/linux/cgroups.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+from pathlib import Path
+from psutil import NoSuchProcess
+from typing import List, Tuple
+
+
+def get_cgroups(pid: int) -> List[Tuple[str, List[str], str]]:
+    """
+    Get the cgroups of a process in [(hier id., controllers, path)] parsed form.
+    """
+    def parse_line(line: str) -> Tuple[str, List[str], str]:
+        hier_id, controller_list, cgroup_path = line.split(':', maxsplit=2)
+        return hier_id, controller_list.split(','), cgroup_path
+
+    try:
+        text = Path(f"/proc/{pid}/cgroup").read_text()
+    except FileNotFoundError:
+        raise NoSuchProcess(pid)
+    else:
+        return [parse_line(line) for line in text.splitlines()]

--- a/granulate_utils/linux/containers.py
+++ b/granulate_utils/linux/containers.py
@@ -4,10 +4,9 @@
 #
 
 import re
-from pathlib import Path
 from typing import Optional, Union
 
-from psutil import NoSuchProcess, Process
+from psutil import Process
 
 from granulate_utils.linux.cgroups import get_cgroups
 


### PR DESCRIPTION
Add `get_cgroups` to parse process cgroups into list of (hierarchy id., controllers, path) tuples.