### PR TITLE
linux/ns: Support recursive symlinks in resolve_proc_root_links

### DIFF
--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -72,10 +72,10 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
                 next_path = proc_root + link
             else:
                 # relative: just join
-                next_path = os.path.join(path, link)
+                next_path = os.path.join(os.path.dirname(next_path), link)
         path = next_path
 
-    return path
+    return os.path.abspath(path)
 
 
 def get_process_nspid(process: Union[Process, int]) -> int:

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -59,9 +59,13 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
     parts = Path(ns_path).parts
 
     path = proc_root
+    seen = set()
     for part in parts[1:]:  # skip the / (or multiple /// as .parts gives them)
         next_path = os.path.join(path, part)
-        if os.path.islink(next_path):
+        while os.path.islink(next_path):
+            if next_path in seen:
+                raise OSError("Symlink loop detected")
+            seen.add(next_path)
             link = os.readlink(next_path)
             if os.path.isabs(link):
                 # absolute - prefix with proc_root

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -64,7 +64,7 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
         next_path = os.path.join(path, part)
         while os.path.islink(next_path):
             if next_path in seen:
-                raise OSError("Symlink loop detected")
+                raise RuntimeError("Symlink loop from %r" % os.path.join(path, part))
             seen.add(next_path)
             link = os.readlink(next_path)
             if os.path.isabs(link):
@@ -75,7 +75,7 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
                 next_path = os.path.join(os.path.dirname(next_path), link)
         path = next_path
 
-    return os.path.abspath(path)
+    return path
 
 
 def get_process_nspid(process: Union[Process, int]) -> int:


### PR DESCRIPTION
`resolve_proc_root_links` would check if some path is a link and resolve it, but then it wouldn't recheck if the resolved path is still a link. We now perform the check in a loop while keeping a set of checked paths to detect a symlink loop.
Note that while `os.path.realpath` and `os.path._joinrealpath` perform similar functionality, they won't prepend the `proc_root` prefix correctly after each link resolving.