### PR TITLE
bugfix: raise error when exe path is empty

### DIFF
--- a/granulate_utils/exceptions.py
+++ b/granulate_utils/exceptions.py
@@ -3,6 +3,8 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
+from psutil import Process
+
 
 class UnsupportedNamespaceError(Exception):
     def __init__(self, nstype: str):
@@ -31,3 +33,10 @@ class ContainerNotFound(Exception):
 class BadResponseCode(Exception):
     def __init__(self, response_code: int):
         super().__init__(f"Got a bad HTTP response code {response_code}")
+
+
+class MissingExePath(Exception):
+    def __init__(self, process: Process):
+        self.process = process
+        super(MissingExePath, self).__init__(
+            f"No exe path was found for pid {process.pid}, threads: {process.threads()}")

--- a/granulate_utils/exceptions.py
+++ b/granulate_utils/exceptions.py
@@ -38,5 +38,4 @@ class BadResponseCode(Exception):
 class MissingExePath(Exception):
     def __init__(self, process: Process):
         self.process = process
-        super(MissingExePath, self).__init__(
-            f"No exe path was found for pid {process.pid}, threads: {process.threads()}")
+        super(MissingExePath, self).__init__(f"No exe path was found for {process}, threads: {process.threads()}")

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -4,6 +4,7 @@
 #
 
 import psutil
+
 from granulate_utils.exceptions import MissingExePath
 
 

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -4,11 +4,7 @@
 #
 
 import psutil
-
-
-class MissingExePath(Exception):
-    def __init__(self, process):
-        super(MissingExePath, self).__init__(f"No exe path was found for pid {process.pid}")
+from granulate_utils.exceptions import MissingExePath
 
 
 def process_exe(process: psutil.Process) -> str:

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -6,6 +6,11 @@
 import psutil
 
 
+class MissingExePath(Exception):
+    def __init__(self, process):
+        super(MissingExePath, self).__init__(f"No exe path was found for pid {process.pid}")
+
+
 def process_exe(process: psutil.Process) -> str:
     """
     psutil.Process(pid).exe() returns "" for zombie processes, incorrectly. It should raise ZombieProcess, and return ""
@@ -14,8 +19,10 @@ def process_exe(process: psutil.Process) -> str:
     See https://github.com/giampaolo/psutil/pull/2062
     """
     exe = process.exe()
-    if exe == "" and is_process_zombie(process):
-        raise psutil.ZombieProcess(process.pid)
+    if exe == "":
+        if is_process_zombie(process):
+            raise psutil.ZombieProcess(process.pid)
+        raise MissingExePath(process)
     return exe
 
 


### PR DESCRIPTION
handling a case of a non-zombie process with no EXE path available in the function process_exe

in the current behavior is that an empty string is returned, the change I am suggesting here is to raise an exception in case of no EXE is available but the process is not zombie
