### PR TITLE
Statically enforce ns types literal to avoid typos in nstypes in various callsites

### DIFF
--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -39,7 +39,7 @@ class NsType(enum.IntFlag):
 
 
 # note: keep in sync with the above NsType, duh.
-ValidNsTypeLiteral = Union[
+NsStr = Union[
     Literal["mnt"],
     Literal["net"],
     Literal["pid"],
@@ -170,7 +170,7 @@ def _get_process_nspid_by_sched_files(process: Process) -> int:
     raise NoSuchProcess(process.pid)
 
 
-def is_same_ns(process: Union[Process, int], nstype: ValidNsTypeLiteral, process2: Union[Process, int] = None) -> bool:
+def is_same_ns(process: Union[Process, int], nstype: NsStr, process2: Union[Process, int] = None) -> bool:
     if isinstance(process, int):
         process = Process(process)
     if isinstance(process2, int):
@@ -185,7 +185,7 @@ def is_same_ns(process: Union[Process, int], nstype: ValidNsTypeLiteral, process
         return True
 
 
-def _get_process_ns_inode(process: Process, nstype: ValidNsTypeLiteral):
+def _get_process_ns_inode(process: Process, nstype: NsStr):
     try:
         ns_inode = os.stat(f"/proc/{process.pid}/ns/{nstype}").st_ino
     except FileNotFoundError as e:
@@ -202,7 +202,7 @@ def _get_process_ns_inode(process: Process, nstype: ValidNsTypeLiteral):
 
 
 def run_in_ns(
-    nstypes: List[ValidNsTypeLiteral],
+    nstypes: List[NsStr],
     callback: Callable[[], T],
     target_pid: int = 1,
     passthrough_exception: bool = False,

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -50,6 +50,10 @@ NsStr = Union[
 ]
 
 
+def assert_ns_str(ns: str) -> None:
+    assert ns in NsType.__members__, f"{ns} is not a valid namespace!"
+
+
 libc: Optional[ctypes.CDLL] = None
 
 
@@ -186,6 +190,7 @@ def is_same_ns(process: Union[Process, int], nstype: NsStr, process2: Union[Proc
 
 
 def _get_process_ns_inode(process: Process, nstype: NsStr):
+    assert_ns_str(nstype)
     try:
         ns_inode = os.stat(f"/proc/{process.pid}/ns/{nstype}").st_ino
     except FileNotFoundError as e:
@@ -220,6 +225,8 @@ def run_in_ns(
     By default, run stuff in init NS. You can pass 'target_pid' to run in the namespace of that process.
     """
 
+    for ns in nstypes:
+        assert_ns_str(ns)
     # make sure "mnt" is last, once we change it our /proc is gone
     nstypes = sorted(nstypes, key=lambda ns: 1 if ns == "mnt" else 0)
 

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -38,7 +38,7 @@ class NsType(enum.IntFlag):
     user = 0x10000000  # CLONE_NEWUSER
 
 
-# TODO: keep in sync with the above NsType, duh.
+# note: keep in sync with the above NsType, duh.
 ValidNsTypeLiteral = Union[
     Literal["mnt"],
     Literal["net"],


### PR DESCRIPTION
I had a hard time debugging some code that uses `is_same_ns` after I found I used `mount` instead of `mnt` as the nstype :(