### PR TITLE
containers: docker: Avoid race in DockerClient.list_containers()

### DIFF
--- a/granulate_utils/containers/docker.py
+++ b/granulate_utils/containers/docker.py
@@ -21,7 +21,7 @@ class DockerClient(ContainersClientInterface):
         self._docker = docker.DockerClient(base_url="unix://" + resolve_host_root_links(DOCKER_SOCK))
 
     def list_containers(self, all_info: bool) -> List[Container]:
-        containers = self._docker.containers.list(ignore_removed=True)
+        containers = self._docker.containers.list(ignore_removed=True)  # ignore_removed to avoid races, see my commit
         return list(map(self._create_container, containers))
 
     def get_container(self, container_id: str, all_info: bool) -> Container:

--- a/granulate_utils/containers/docker.py
+++ b/granulate_utils/containers/docker.py
@@ -21,7 +21,7 @@ class DockerClient(ContainersClientInterface):
         self._docker = docker.DockerClient(base_url="unix://" + resolve_host_root_links(DOCKER_SOCK))
 
     def list_containers(self, all_info: bool) -> List[Container]:
-        containers = self._docker.containers.list()
+        containers = self._docker.containers.list(ignore_removed=True)
         return list(map(self._create_container, containers))
 
     def get_container(self, container_id: str, all_info: bool) -> Container:


### PR DESCRIPTION
I got this race:
```
  ...
  File "granulate_utils.containers.client", line 44, in list_containers
  File "granulate_utils.containers.docker", line 24, in list_containers
  File "docker.models.containers", line 953, in list
  File "docker.models.containers", line 889, in get
  File "docker.utils.decorators", line 19, in wrapped
  File "docker.api.container", line 773, in inspect_container
  File "docker.api.client", line 274, in _result
  File "docker.api.client", line 270, in _raise_for_status
  File "docker.errors", line 31, in create_api_error_from_http_exception
docker.errors.NotFound: 404 Client Error for http+docker://localhost/v1.41/containers/xxx/json: Not Found ("No such container: xxx")
```

Found a ticket in docker-py suggesting the use of `ignore_removed`, https://github.com/docker/docker-py/issues/2451#issuecomment-545077576