### PR TITLE
mypy: set platform to linux

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 python_version = 3.6
+platform = linux
 warn_unused_configs = True
 
 # no types in package / types- package :(


### PR DESCRIPTION
When running `lint.sh` on Mac mypy cries with:

```console
error: "Process" has no attribute "memory_maps"
```

because `memory_maps` is defined on `Process` only when platform is not "darwin": https://github.com/python/typeshed/blob/master/stubs/psutil/psutil/__init__.pyi#L191