### PR TITLE
cgroups: Find v1/v2 hierarchies

### DIFF
--- a/granulate_utils/exceptions.py
+++ b/granulate_utils/exceptions.py
@@ -39,3 +39,8 @@ class MissingExePath(Exception):
     def __init__(self, process: Process):
         self.process = process
         super(MissingExePath, self).__init__(f"No exe path was found for {process}, threads: {process.threads()}")
+
+
+class AlreadyInCgroup(Exception):
+    def __init__(self, subsystem: str, cgroup: str) -> None:
+        super().__init__(f"{subsystem!r} subsytem is already in a predefined cgroup: {cgroup!r}")

--- a/granulate_utils/linux/cgroups/__init__.py
+++ b/granulate_utils/linux/cgroups/__init__.py
@@ -4,6 +4,6 @@
 #
 
 from granulate_utils.exceptions import AlreadyInCgroup  # noqa: F401
-from granulate_utils.linux.cgroups.base_cgroup import get_cgroups  # noqa: F401
+from granulate_utils.linux.cgroups.cgroup import get_cgroups  # noqa: F401
 from granulate_utils.linux.cgroups.cpu_cgroup import CpuCgroup  # noqa: F401
 from granulate_utils.linux.cgroups.memory_cgroup import MemoryCgroup  # noqa: F401

--- a/granulate_utils/linux/cgroups/__init__.py
+++ b/granulate_utils/linux/cgroups/__init__.py
@@ -3,6 +3,7 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
-from granulate_utils.linux.cgroups.base_cgroup import AlreadyInCgroup, get_cgroups  # noqa: F401
+from granulate_utils.linux.cgroups.base_cgroup import get_cgroups  # noqa: F401
 from granulate_utils.linux.cgroups.cpu_cgroup import CpuCgroup  # noqa: F401
 from granulate_utils.linux.cgroups.memory_cgroup import MemoryCgroup  # noqa: F401
+from granulate_utils.exceptions import AlreadyInCgroup

--- a/granulate_utils/linux/cgroups/__init__.py
+++ b/granulate_utils/linux/cgroups/__init__.py
@@ -3,7 +3,7 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
+from granulate_utils.exceptions import AlreadyInCgroup  # noqa: F401
 from granulate_utils.linux.cgroups.base_cgroup import get_cgroups  # noqa: F401
 from granulate_utils.linux.cgroups.cpu_cgroup import CpuCgroup  # noqa: F401
 from granulate_utils.linux.cgroups.memory_cgroup import MemoryCgroup  # noqa: F401
-from granulate_utils.exceptions import AlreadyInCgroup

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -5,7 +5,7 @@
 
 import os
 from pathlib import Path
-from typing import List, Mapping
+from typing import List, Mapping, Optional
 
 from granulate_utils.exceptions import AlreadyInCgroup
 from granulate_utils.linux.cgroups.cgroup import SUBSYSTEMS, find_v1_hierarchies, get_cgroups
@@ -13,16 +13,16 @@ from granulate_utils.linux.cgroups.cgroup import SUBSYSTEMS, find_v1_hierarchies
 
 class BaseCgroup:
     predefined_cgroups = ["kubepods", "docker", "ecs"]
-    _v1_hierarchies = None
+    _v1_hierarchies: Optional[Mapping[str, str]] = None
 
     def __init__(self) -> None:
         self._verify_preconditions()
 
-    @classmethod
-    def get_cgroup_hierarchies(cls) -> Mapping[str, str]:
-        if cls._v1_hierarchies is None:
-            cls._v1_hierarchies = find_v1_hierarchies()
-        return cls._v1_hierarchies
+    @staticmethod
+    def get_cgroup_hierarchies() -> Mapping[str, str]:
+        if BaseCgroup._v1_hierarchies is None:
+            BaseCgroup._v1_hierarchies = find_v1_hierarchies()
+        return BaseCgroup._v1_hierarchies
 
     def _verify_preconditions(self) -> None:
         assert self.subsystem in SUBSYSTEMS, f"{self.subsystem!r} is not supported"

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List
 
 from granulate_utils.exceptions import AlreadyInCgroup
-from granulate_utils.linux.cgroups.cgroup import CGROUPFS, SUBSYSTEMS, find_v1_hierarchies, get_cgroups
+from granulate_utils.linux.cgroups.cgroup import SUBSYSTEMS, find_v1_hierarchies, get_cgroups
 
 
 class BaseCgroup:

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -8,14 +8,12 @@ from pathlib import Path
 from typing import List, Tuple
 
 from psutil import NoSuchProcess
+from granulate_utils.exceptions import AlreadyInCgroup
 
 CGROUPFS = Path("/sys/fs/cgroup")
 SUBSYSTEMS = {"memory", "cpu"}
 
 
-class AlreadyInCgroup(Exception):
-    def __init__(self, subsystem: str, cgroup: str) -> None:
-        super().__init__(f"{subsystem!r} subsytem is already in a predefined cgroup: {cgroup!r}")
 
 
 def get_cgroups(pid: int) -> List[Tuple[str, List[str], str]]:

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -4,6 +4,7 @@
 #
 
 import os
+from functools import cached_property
 from pathlib import Path
 from typing import List
 
@@ -43,10 +44,10 @@ class BaseCgroup:
 
     @property
     def cgroup_mount_path(self) -> Path:
-        return Path(self.cgroup_fs / self.cgroup[1:])
+        return Path(self.cgroup_path / self.cgroup[1:])
 
-    @property
-    def cgroup_fs(self) -> Path:
+    @cached_property
+    def cgroup_path(self) -> Path:
         v1_hierarchies = find_v1_hierarchies()
         return Path(v1_hierarchies[self.subsystem])
 

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -43,9 +43,10 @@ class BaseCgroup:
 
     @property
     def cgroup_mount_path(self) -> Path:
-        return Path(self.get_cgroup_fs() / self.cgroup[1:])
+        return Path(self.cgroup_fs / self.cgroup[1:])
 
-    def get_cgroup_fs(self) -> Path:
+    @property
+    def cgroup_fs(self) -> Path:
         v1_hierarchies = find_v1_hierarchies()
         return Path(v1_hierarchies[self.subsystem])
 

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -13,7 +13,7 @@ from granulate_utils.linux.cgroups.cgroup import SUBSYSTEMS, find_v1_hierarchies
 
 class BaseCgroup:
     predefined_cgroups = ["kubepods", "docker", "ecs"]
-    _v1_hierarchies: Mapping[str, str]
+    _v1_hierarchies = None
 
     def __init__(self) -> None:
         self._verify_preconditions()

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -4,7 +4,6 @@
 #
 
 import os
-from functools import cached_property
 from pathlib import Path
 from typing import List
 
@@ -14,6 +13,7 @@ from granulate_utils.linux.cgroups.cgroup import SUBSYSTEMS, find_v1_hierarchies
 
 class BaseCgroup:
     predefined_cgroups = ["kubepods", "docker", "ecs"]
+    v1_hierarchies = find_v1_hierarchies()
 
     def __init__(self) -> None:
         self._verify_preconditions()
@@ -46,10 +46,9 @@ class BaseCgroup:
     def cgroup_mount_path(self) -> Path:
         return Path(self.cgroup_path / self.cgroup[1:])
 
-    @cached_property
+    @property
     def cgroup_path(self) -> Path:
-        v1_hierarchies = find_v1_hierarchies()
-        return Path(v1_hierarchies[self.subsystem])
+        return Path(self.v1_hierarchies[self.subsystem])
 
     def move_to_cgroup(self, custom_cgroup: str, tid: int = 0) -> None:
         # move to a new cgroup inside the current cgroup

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -5,15 +5,61 @@
 
 import os
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Mapping, Optional, Tuple
 
 from psutil import NoSuchProcess
+
 from granulate_utils.exceptions import AlreadyInCgroup
+from granulate_utils.linux.mountinfo import iter_mountinfo
+from granulate_utils.linux.ns import resolve_host_root_links
 
+# TODO: This is not always correct. For example, on Amazon Linux 1 this should be /cgroup.
 CGROUPFS = Path("/sys/fs/cgroup")
-SUBSYSTEMS = {"memory", "cpu"}
+SUBSYSTEMS = {
+    "blkio",
+    "cpu",
+    "cpuacct",
+    "cpuset",
+    "devices",
+    "freezer",
+    "hugetlb",
+    "memory",
+    "net_cls",
+    "net_prio",
+    "perf_event",
+    "pids",
+    "rdma",
+}
 
 
+def find_v1_hierarchies() -> Mapping[str, str]:
+    """
+    Finds all the mounted hierarchies for all currently enabled cgroup v1 controllers.
+    :return: A mapping from cgroup subsystem names to their respective hierarchies.
+    """
+    hierarchies = {}
+    for mount in iter_mountinfo(1):
+        # The mount source is always "cgroup" by convention, we don't really have to check it.
+        if mount.mount_source != "cgroup" or mount.filesystem_type != "cgroup":
+            continue
+        controllers = set(mount.super_options) & SUBSYSTEMS
+        if controllers:
+            hierarchy = resolve_host_root_links(mount.mount_point)
+            for controller in controllers:
+                hierarchies[controller] = hierarchy
+    return hierarchies
+
+
+def find_v2_hierarchy() -> Optional[str]:
+    """
+    Finds the mounted unified hierarchy for cgroup v2 controllers.
+    """
+    cgroup2_mounts = [mount for mount in iter_mountinfo(1) if mount.filesystem_type == "cgroup2"]
+    if not cgroup2_mounts:
+        return None
+    if len(cgroup2_mounts) > 1:
+        raise Exception("More than one cgroup2 mount found!")
+    return resolve_host_root_links(cgroup2_mounts[0].mount_point)
 
 
 def get_cgroups(pid: int) -> List[Tuple[str, List[str], str]]:

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -5,78 +5,10 @@
 
 import os
 from pathlib import Path
-from typing import List, Mapping, Optional, Tuple
-
-from psutil import NoSuchProcess
+from typing import List
 
 from granulate_utils.exceptions import AlreadyInCgroup
-from granulate_utils.linux.mountinfo import iter_mountinfo
-from granulate_utils.linux.ns import resolve_host_root_links
-
-# TODO: This is not always correct. For example, on Amazon Linux 1 this should be /cgroup.
-CGROUPFS = Path("/sys/fs/cgroup")
-SUBSYSTEMS = {
-    "blkio",
-    "cpu",
-    "cpuacct",
-    "cpuset",
-    "devices",
-    "freezer",
-    "hugetlb",
-    "memory",
-    "net_cls",
-    "net_prio",
-    "perf_event",
-    "pids",
-    "rdma",
-}
-
-
-def find_v1_hierarchies() -> Mapping[str, str]:
-    """
-    Finds all the mounted hierarchies for all currently enabled cgroup v1 controllers.
-    :return: A mapping from cgroup subsystem names to their respective hierarchies.
-    """
-    hierarchies = {}
-    for mount in iter_mountinfo(1):
-        # The mount source is always "cgroup" by convention, we don't really have to check it.
-        if mount.mount_source != "cgroup" or mount.filesystem_type != "cgroup":
-            continue
-        controllers = set(mount.super_options) & SUBSYSTEMS
-        if controllers:
-            hierarchy = resolve_host_root_links(mount.mount_point)
-            for controller in controllers:
-                hierarchies[controller] = hierarchy
-    return hierarchies
-
-
-def find_v2_hierarchy() -> Optional[str]:
-    """
-    Finds the mounted unified hierarchy for cgroup v2 controllers.
-    """
-    cgroup2_mounts = [mount for mount in iter_mountinfo(1) if mount.filesystem_type == "cgroup2"]
-    if not cgroup2_mounts:
-        return None
-    if len(cgroup2_mounts) > 1:
-        raise Exception("More than one cgroup2 mount found!")
-    return resolve_host_root_links(cgroup2_mounts[0].mount_point)
-
-
-def get_cgroups(pid: int) -> List[Tuple[str, List[str], str]]:
-    """
-    Get the cgroups of a process in [(hier id., controllers, path)] parsed form.
-    """
-
-    def parse_line(line: str) -> Tuple[str, List[str], str]:
-        hier_id, controller_list, cgroup_path = line.split(":", maxsplit=2)
-        return hier_id, controller_list.split(","), cgroup_path
-
-    try:
-        text = Path(f"/proc/{pid}/cgroup").read_text()
-    except FileNotFoundError:
-        raise NoSuchProcess(pid)
-    else:
-        return [parse_line(line) for line in text.splitlines()]
+from granulate_utils.linux.cgroups.cgroup import CGROUPFS, SUBSYSTEMS, get_cgroups
 
 
 class BaseCgroup:

--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List
 
 from granulate_utils.exceptions import AlreadyInCgroup
-from granulate_utils.linux.cgroups.cgroup import CGROUPFS, SUBSYSTEMS, get_cgroups
+from granulate_utils.linux.cgroups.cgroup import CGROUPFS, SUBSYSTEMS, find_v1_hierarchies, get_cgroups
 
 
 class BaseCgroup:
@@ -43,7 +43,11 @@ class BaseCgroup:
 
     @property
     def cgroup_mount_path(self) -> Path:
-        return Path(CGROUPFS / self.subsystem / self.cgroup[1:])
+        return Path(self.get_cgroup_fs() / self.cgroup[1:])
+
+    def get_cgroup_fs(self) -> Path:
+        v1_hierarchies = find_v1_hierarchies()
+        return Path(v1_hierarchies[self.subsystem])
 
     def move_to_cgroup(self, custom_cgroup: str, tid: int = 0) -> None:
         # move to a new cgroup inside the current cgroup

--- a/granulate_utils/linux/cgroups/cgroup.py
+++ b/granulate_utils/linux/cgroups/cgroup.py
@@ -1,0 +1,78 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+
+from pathlib import Path
+from typing import List, Mapping, Optional, Tuple
+
+from psutil import NoSuchProcess
+
+from granulate_utils.linux.mountinfo import iter_mountinfo
+from granulate_utils.linux.ns import resolve_host_root_links
+
+SUBSYSTEMS = {
+    "blkio",
+    "cpu",
+    "cpuacct",
+    "cpuset",
+    "devices",
+    "freezer",
+    "hugetlb",
+    "memory",
+    "net_cls",
+    "net_prio",
+    "perf_event",
+    "pids",
+    "rdma",
+}
+
+# TODO: This is not always correct. For example, on Amazon Linux 1 this should be /cgroup.
+CGROUPFS = Path("/sys/fs/cgroup")
+
+
+def get_cgroups(pid: int) -> List[Tuple[str, List[str], str]]:
+    """
+    Get the cgroups of a process in [(hier id., controllers, path)] parsed form.
+    """
+
+    def parse_line(line: str) -> Tuple[str, List[str], str]:
+        hier_id, controller_list, cgroup_path = line.split(":", maxsplit=2)
+        return hier_id, controller_list.split(","), cgroup_path
+
+    try:
+        text = Path(f"/proc/{pid}/cgroup").read_text()
+    except FileNotFoundError:
+        raise NoSuchProcess(pid)
+    else:
+        return [parse_line(line) for line in text.splitlines()]
+
+
+def find_v1_hierarchies() -> Mapping[str, str]:
+    """
+    Finds all the mounted hierarchies for all currently enabled cgroup v1 controllers.
+    :return: A mapping from cgroup subsystem names to their respective hierarchies.
+    """
+    hierarchies = {}
+    for mount in iter_mountinfo(1):
+        # The mount source is always "cgroup" by convention, we don't really have to check it.
+        if mount.mount_source != "cgroup" or mount.filesystem_type != "cgroup":
+            continue
+        controllers = set(mount.super_options) & SUBSYSTEMS
+        if controllers:
+            hierarchy = resolve_host_root_links(mount.mount_point)
+            for controller in controllers:
+                hierarchies[controller] = hierarchy
+    return hierarchies
+
+
+def find_v2_hierarchy() -> Optional[str]:
+    """
+    Finds the mounted unified hierarchy for cgroup v2 controllers.
+    """
+    cgroup2_mounts = [mount for mount in iter_mountinfo(1) if mount.filesystem_type == "cgroup2"]
+    if not cgroup2_mounts:
+        return None
+    if len(cgroup2_mounts) > 1:
+        raise Exception("More than one cgroup2 mount found!")
+    return resolve_host_root_links(cgroup2_mounts[0].mount_point)

--- a/granulate_utils/linux/cgroups/cgroup.py
+++ b/granulate_utils/linux/cgroups/cgroup.py
@@ -27,9 +27,6 @@ SUBSYSTEMS = {
     "rdma",
 }
 
-# TODO: This is not always correct. For example, on Amazon Linux 1 this should be /cgroup.
-CGROUPFS = Path("/sys/fs/cgroup")
-
 
 def get_cgroups(pid: int) -> List[Tuple[str, List[str], str]]:
     """

--- a/granulate_utils/linux/containers.py
+++ b/granulate_utils/linux/containers.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 from psutil import Process
 
-import granulate_utils.linux.cgroups as cgroups
+from granulate_utils.linux import cgroups
 
 # ECS uses /ecs/uuid/container-id
 # standard Docker uses /docker/container-id

--- a/granulate_utils/linux/containers.py
+++ b/granulate_utils/linux/containers.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 from psutil import Process
 
-from granulate_utils.linux.cgroups import get_cgroups
+import granulate_utils.linux.cgroups as cgroups
 
 # ECS uses /ecs/uuid/container-id
 # standard Docker uses /docker/container-id
@@ -24,7 +24,7 @@ def get_process_container_id(process: Union[int, Process]) -> Optional[str]:
     :raises NoSuchProcess: If the process doesn't or no longer exists
     """
     pid = process if isinstance(process, int) else process.pid
-    for _, _, cgpath in get_cgroups(pid):
+    for _, _, cgpath in cgroups.get_cgroups(pid):
         found = CONTAINER_ID_PATTERN.findall(cgpath)
         if found:
             return found[-1]

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -13,8 +13,8 @@ from typing import Callable, List, Optional, TypeVar, Union
 
 from psutil import NoSuchProcess, Process, process_iter
 
-import granulate_utils.linux.containers as containers
 from granulate_utils.exceptions import UnsupportedNamespaceError
+from granulate_utils.linux import containers
 
 T = TypeVar("T")
 

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -14,7 +14,6 @@ from typing import Callable, List, Optional, TypeVar, Union
 from psutil import NoSuchProcess, Process, process_iter
 
 from granulate_utils.exceptions import UnsupportedNamespaceError
-from granulate_utils.linux.containers import get_process_container_id
 
 T = TypeVar("T")
 
@@ -315,6 +314,8 @@ def resolve_host_path(process: Process, ns_path: str, from_ancestor: bool = True
 
 
 def get_host_pid(nspid: int, container_id: str) -> Optional[int]:
+    from granulate_utils.linux.containers import get_process_container_id
+
     assert len(container_id) == 64, f"Invalid container id {container_id!r}"
 
     pid_namespace = ""

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -13,6 +13,7 @@ from typing import Callable, List, Optional, TypeVar, Union
 
 from psutil import NoSuchProcess, Process, process_iter
 
+import granulate_utils.linux.containers as containers
 from granulate_utils.exceptions import UnsupportedNamespaceError
 
 T = TypeVar("T")
@@ -314,8 +315,6 @@ def resolve_host_path(process: Process, ns_path: str, from_ancestor: bool = True
 
 
 def get_host_pid(nspid: int, container_id: str) -> Optional[int]:
-    from granulate_utils.linux.containers import get_process_container_id
-
     assert len(container_id) == 64, f"Invalid container id {container_id!r}"
 
     pid_namespace = ""
@@ -324,7 +323,7 @@ def get_host_pid(nspid: int, container_id: str) -> Optional[int]:
     # Get the pid namespace of the given container
     for process in running_processes:
         try:
-            if container_id == get_process_container_id(process):
+            if container_id == containers.get_process_container_id(process):
                 pid_namespace = os.readlink(f"/proc/{process.pid}/ns/pid")
                 break
         except (FileNotFoundError, NoSuchProcess):

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,6 @@ ignore_missing_imports = True
 # mypy follows into those files, I believe because they are imported.
 [mypy-granulate_utils.generated.*]
 ignore_errors = True
+
+[mypy-cached_property.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,3 @@ ignore_missing_imports = True
 # mypy follows into those files, I believe because they are imported.
 [mypy-granulate_utils.generated.*]
 ignore_errors = True
-
-[mypy-cached_property.*]
-ignore_missing_imports = True


### PR DESCRIPTION
Added `find_v1_hierarchies` and `find_v2_hierarchy` to find where the hierarchies for v1/v2 controllers are mounted.

- [x] @marina-vrublevsky Note that `CGROUPFS = Path("/sys/fs/cgroup")` is incorrect on Amazon Linux 1 - fixed here by utilizing `find_v1_hierarchies`

