### PR TITLE
Relax requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-psutil==5.8.0
+psutil~=5.8.0
 requests~=2.27.1
-grpcio==1.43.0
-protobuf==3.19.4
+grpcio~=1.43.0
+protobuf~=3.19.4
 docker~=5.0.0
-dataclasses==0.8; python_version < '3.7'
+dataclasses~=0.8; python_version < '3.7'
 typing-extensions>=4.1.0
-pyelftools==0.28
+pyelftools~=0.28
 packaging~=21.2


### PR DESCRIPTION
The requirements are too strict and prevent installation of newer patch versions.