### PR TITLE
cgroups: memory: fixed set_limit_in_bytes

### DIFF
--- a/granulate_utils/linux/cgroups/memory_cgroup.py
+++ b/granulate_utils/linux/cgroups/memory_cgroup.py
@@ -27,12 +27,13 @@ class MemoryCgroup(BaseCgroup):
             pass
 
     def set_limit_in_bytes(self, limit: int) -> None:
-        # in case memsw_limit_in_bytes file exists we need to reset it in order to
-        # change limit_in_bytes in case it's smaller than memsw_limit_in_bytes
+        # in case memsw.limit_in_bytes file exists we need to reset it in order to
+        # change limit_in_bytes in case it's smaller than memsw.limit_in_bytes
         self._set_memsw_limit_in_bytes(-1)
         self.write_to_control_file(self.limit_in_bytes, str(limit))
+
+        # memsw.limit_in_bytes is already set to -1
         if limit != -1:
-            # memsw_limit_in_bytes already happend for -1
             self._set_memsw_limit_in_bytes(limit)
 
     def reset_memory_limit(self) -> None:

--- a/granulate_utils/linux/cgroups/memory_cgroup.py
+++ b/granulate_utils/linux/cgroups/memory_cgroup.py
@@ -18,8 +18,7 @@ class MemoryCgroup(BaseCgroup):
     def get_max_usage_in_bytes(self) -> int:
         return int(self.read_from_control_file(self.max_usage_in_bytes))
 
-    def set_limit_in_bytes(self, limit: int) -> None:
-        self.write_to_control_file(self.limit_in_bytes, str(limit))
+    def _set_memsw_limit_in_bytes(self, limit: int) -> None:
         try:
             self.write_to_control_file(self.memsw_limit_in_bytes, str(limit))
         except PermissionError:
@@ -27,5 +26,14 @@ class MemoryCgroup(BaseCgroup):
             # and PermissionError is thrown (since it can't be created)
             pass
 
+    def set_limit_in_bytes(self, limit: int) -> None:
+        # in case memsw_limit_in_bytes file exists we need to reset it in order to
+        # change limit_in_bytes in case it's smaller than memsw_limit_in_bytes
+        self._set_memsw_limit_in_bytes(-1)
+        self.write_to_control_file(self.limit_in_bytes, str(limit))
+        if limit != -1:
+            # memsw_limit_in_bytes already happend for -1
+            self._set_memsw_limit_in_bytes(limit)
+
     def reset_memory_limit(self) -> None:
-        self.write_to_control_file(self.limit_in_bytes, "-1")
+        self.set_limit_in_bytes(-1)


### PR DESCRIPTION
1. Ensure we reset `memsw.limit_in_bytes` (in case it exists) in order to allow changing `limit_in_bytes` in case it's smaller than `memsw.limit_in_bytes` (or we will experience `write error: Invalid argument`)
2. Fix `reset_memory_limit` which previously didn't reset  `memsw.limit_in_bytes` (in case it exists)