### PR TITLE
Added get_elf_arch() that reads the binary architecture from the ELF section of the file

### DIFF
--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -12,7 +12,7 @@ from elftools.elf.sections import NoteSection  # type: ignore
 
 def get_elf_arch(path: str) -> str:
     """
-    Gets the file architacture embedded in an ELF file section
+    Gets the file architecture embedded in an ELF file section
     """
     with open(path, "rb") as f:
         elf = ELFFile(f)

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -12,7 +12,6 @@ from elftools.elf.sections import NoteSection  # type: ignore
 
 def get_elf_arch(path: str) -> str:
     """
-
     Gets the file architacture embedded in an ELF file section
     """
     with open(path, "rb") as f:

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -10,6 +10,16 @@ from elftools.elf.elffile import ELFFile  # type: ignore
 from elftools.elf.sections import NoteSection  # type: ignore
 
 
+def get_elf_arch(path: str) -> str:
+    """
+
+    Gets the file architacture embedded in an ELF file section
+    """
+    with open(path, "rb") as f:
+        elf = ELFFile(f)
+        return elf.get_machine_arch()
+
+
 def get_elf_buildid(path: str) -> Optional[str]:
     """
     Gets the build ID embedded in an ELF file section as a hex string,


### PR DESCRIPTION
Added get_elf_arch() that reads the binary architecture from the ELF section of the file

# Tests
- [x] - Run the function on an arm binary and the function returned - 'AArch64'
- [x] - Run the function on an x86_64 binary and the function returned - 'x64'
