### PR TITLE
glogger: Add formatting to stdout_handler

### DIFF
--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -9,7 +9,7 @@ import uuid
 from json import JSONEncoder
 from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
-from requests import HTTPError, Session
+from requests import Session
 
 from glogger.messages_buffer import MessagesBuffer
 
@@ -121,8 +121,6 @@ class Sender:
         try:
             batch = self._send_once()
             self._drop_sent_batch(batch)
-        except HTTPError:
-            self.stdout_logger.error(SERVER_SEND_ERROR_MESSAGE)
         except Exception:
             self.stdout_logger.exception(SERVER_SEND_ERROR_MESSAGE)
 

--- a/glogger/stdout_logger.py
+++ b/glogger/stdout_logger.py
@@ -5,12 +5,17 @@
 import logging
 import sys
 
+_LOGGING_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+
 
 # Use the stdout logger because we don't want to log
 # recursively from inside the logger implementation
 def get_stdout_logger():
     stdout_logger = logging.getLogger(__name__ + "_stdout")
     stdout_logger.propagate = False
-    stdout_logger.addHandler(logging.StreamHandler(sys.stdout))
+    formatter = logging.Formatter(_LOGGING_FORMAT)
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(formatter)
+    stdout_logger.addHandler(stdout_handler)
     stdout_logger.setLevel(logging.INFO)
     return stdout_logger


### PR DESCRIPTION
Adding formatting to stdout handler so we have level and time and not just the message.
Also removing the special handling of HTTPError in the sender - so we have the actual error in the log.