### PR TITLE
elf: Add get_libc_type

### DIFF
--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -10,7 +10,6 @@ from typing import List, Optional, cast
 from elftools.elf.elffile import ELFError, ELFFile  # type: ignore
 from elftools.elf.sections import NoteSection  # type: ignore
 
-
 __all__ = ["ELFError"]
 
 

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -142,6 +142,9 @@ def get_libc_type(path: str) -> LibcType:
     if found_glibc:
         return LibcType.DYNAMIC_GLIBC
 
+    # This symbol exists in both musl and glibc, and is even used by musl to recognize a DSO as a libc.
+    # They even comment that it works on both musl and glibc.
+    # https://github.com/bminor/musl/blob/dc9285ad1dc19349c407072cc48ba70dab86de45/ldso/dynlink.c#L1143-L1152
     if get_symbol_addr(path, "__libc_start_main") is not None:
         return LibcType.STATIC_LIBC
 

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -4,8 +4,10 @@
 #
 
 import hashlib
+from contextlib import contextmanager
 from enum import Enum, auto
-from typing import List, Optional, cast
+from pathlib import Path
+from typing import List, Optional, Union, cast
 
 from elftools.elf.elffile import ELFError, ELFFile  # type: ignore
 from elftools.elf.sections import NoteSection  # type: ignore
@@ -20,22 +22,32 @@ class LibcType(Enum):
     STATIC_NO_LIBC = auto()
 
 
-def get_elf_arch(path: str) -> str:
+ELFType = Union[ELFFile, Path, str]
+
+
+@contextmanager
+def open_elf(elf: ELFType) -> ELFFile:
+    if isinstance(elf, ELFFile):
+        yield elf
+    else:
+        with open(elf, "rb") as f:
+            yield ELFFile(f)
+
+
+def get_elf_arch(elf: ELFType) -> str:
     """
     Gets the file architecture embedded in the ELF file section
     """
-    with open(path, "rb") as f:
-        elf = ELFFile(f)
+    with open_elf(elf) as elf:
         return elf.get_machine_arch()
 
 
-def get_elf_buildid(path: str) -> Optional[str]:
+def get_elf_buildid(elf: ELFType) -> Optional[str]:
     """
     Gets the build ID embedded in an ELF file section as a hex string,
     or None if not present.
     """
-    with open(path, "rb") as f:
-        elf = ELFFile(f)
+    with open_elf(elf) as elf:
         build_id_section = elf.get_section_by_name(".note.gnu.build-id")
         if build_id_section is None or not isinstance(build_id_section, NoteSection):
             return None
@@ -47,63 +59,51 @@ def get_elf_buildid(path: str) -> Optional[str]:
             return None
 
 
-def get_elf_id(path: str) -> str:
+def get_elf_id(elf: ELFType) -> str:
     """
     Gets an identifier for this ELF.
     We prefer to use buildids. If a buildid does not exist for an ELF file,
     we instead grab its SHA1.
     """
-    buildid = get_elf_buildid(path)
-    if buildid is not None:
-        return f"buildid:{buildid}"
+    with open_elf(elf) as elf:
+        buildid = get_elf_buildid(elf)
+        if buildid is not None:
+            return f"buildid:{buildid}"
 
-    # hash in one chunk
-    with open(path, "rb") as f:
-        return f"sha1:{hashlib.sha1(f.read()).hexdigest()}"
-
-
-def _read_va_from_elf(elf: ELFFile, va: int, size: int) -> Optional[bytes]:
-    for section in elf.iter_sections():
-        section_start = section.header.sh_addr
-        section_end = section.header.sh_addr + section.header.sh_size
-        if section_start <= va and section_end >= va + size:
-            offset_from_section = va - section_start
-            return section.data()[offset_from_section : offset_from_section + size]
-    return None
+        # hash in one chunk
+        with open(elf.stream.name, "rb") as f:
+            return f"sha1:{hashlib.sha1(f.read()).hexdigest()}"
 
 
-def read_elf_va(path: str, va: int, size: int) -> Optional[bytes]:
-    with open(path, "rb") as f:
-        elf = ELFFile(f)
-        return _read_va_from_elf(elf, va, size)
+def read_elf_va(elf: ELFType, va: int, size: int) -> Optional[bytes]:
+    with open_elf(elf) as elf:
+        for section in elf.iter_sections():
+            section_start = section.header.sh_addr
+            section_end = section.header.sh_addr + section.header.sh_size
+            if section_start <= va and section_end >= va + size:
+                offset_from_section = va - section_start
+                return section.data()[offset_from_section : offset_from_section + size]
+        return None
 
 
-def read_elf_symbol(path: str, sym_name: str, size: int) -> Optional[bytes]:
-    with open(path, "rb") as f:
-        elf = ELFFile(f)
-        symtab = elf.get_section_by_name(".symtab")
-        if symtab is None:
+def read_elf_symbol(elf: ELFType, sym_name: str, size: int) -> Optional[bytes]:
+    with open_elf(elf) as elf:
+        addr = get_symbol_addr(elf, sym_name)
+        if addr is None:
             return None
-        symbols = symtab.get_symbol_by_name(sym_name)
-        if symbols is None:
-            return None
-        if len(symbols) != 1:
-            raise Exception(f"Multiple symbols match the same name: {sym_name!r}")
-        return _read_va_from_elf(elf, symbols[0].entry.st_value, size)
+        return read_elf_va(elf, addr, size)
 
 
-def is_statically_linked(path: str) -> bool:
-    with open(path, "rb") as f:
-        elf = ELFFile(f)
+def is_statically_linked(elf: ELFType) -> bool:
+    with open_elf(elf) as elf:
         for segment in elf.iter_segments():
             if segment.header.p_type == "PT_DYNAMIC":
                 return False
     return True
 
 
-def get_symbol_addr(path: str, sym_name: str) -> Optional[int]:
-    with open(path, "rb") as f:
-        elf = ELFFile(f)
+def get_symbol_addr(elf: ELFType, sym_name: str) -> Optional[int]:
+    with open_elf(elf) as elf:
         symtab = elf.get_section_by_name(".symtab")
         if symtab is None:
             return None
@@ -115,41 +115,41 @@ def get_symbol_addr(path: str, sym_name: str) -> Optional[int]:
         return symbols[0].entry.st_value
 
 
-def get_dt_needed(path: str) -> Optional[List[str]]:
-    with open(path, "rb") as f:
-        elf = ELFFile(f)
+def get_dt_needed(elf: ELFType) -> Optional[List[str]]:
+    with open_elf(elf) as elf:
         dynamic_section = elf.get_section_by_name(".dynamic")
         if dynamic_section is None:
             return None
         return [tag.needed for tag in dynamic_section.iter_tags() if tag.entry.d_tag == "DT_NEEDED"]
 
 
-def get_libc_type(path: str) -> LibcType:
-    dt_needed = get_dt_needed(path)
-    if dt_needed is not None:
-        found_glibc = False
-        found_musl = False
-        for needed in dt_needed:
-            if "libc.so.6" in needed:
-                found_glibc = True
-            if "ld-linux" in needed:
-                found_glibc = True
-            if "libc.musl" in needed:
-                found_musl = True
-            if "ld-musl" in needed:
-                found_musl = True
-        if found_glibc and found_musl:
-            raise Exception(f"Found both musl and glibc in the same binary: {path!r}")
-        if found_musl:
-            return LibcType.DYNAMIC_MUSL
-        if found_glibc:
-            return LibcType.DYNAMIC_GLIBC
-        raise Exception(f"Foind a dynamic binary without a libc: {path!r}")
+def get_libc_type(elf: ELFType) -> LibcType:
+    with open_elf(elf) as elf:
+        dt_needed = get_dt_needed(elf)
+        if dt_needed is not None:
+            found_glibc = False
+            found_musl = False
+            for needed in dt_needed:
+                if "libc.so.6" in needed:
+                    found_glibc = True
+                if "ld-linux" in needed:
+                    found_glibc = True
+                if "libc.musl" in needed:
+                    found_musl = True
+                if "ld-musl" in needed:
+                    found_musl = True
+            if found_glibc and found_musl:
+                raise Exception(f"Found both musl and glibc in the same binary: {elf.stream.name!r}")
+            if found_musl:
+                return LibcType.DYNAMIC_MUSL
+            if found_glibc:
+                return LibcType.DYNAMIC_GLIBC
+            raise Exception(f"Foind a dynamic binary without a libc: {elf.stream.name!r}")
 
-    # This symbol exists in both musl and glibc, and is even used by musl to recognize a DSO as a libc.
-    # They even comment that it works on both musl and glibc.
-    # https://github.com/bminor/musl/blob/dc9285ad1dc19349c407072cc48ba70dab86de45/ldso/dynlink.c#L1143-L1152
-    if get_symbol_addr(path, "__libc_start_main") is not None:
-        return LibcType.STATIC_LIBC
+        # This symbol exists in both musl and glibc, and is even used by musl to recognize a DSO as a libc.
+        # They even comment that it works on both musl and glibc.
+        # https://github.com/bminor/musl/blob/dc9285ad1dc19349c407072cc48ba70dab86de45/ldso/dynlink.c#L1143-L1152
+        if get_symbol_addr(elf, "__libc_start_main") is not None:
+            return LibcType.STATIC_LIBC
 
-    return LibcType.STATIC_NO_LIBC
+        return LibcType.STATIC_NO_LIBC

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -144,7 +144,7 @@ def get_libc_type(elf: ELFType) -> LibcType:
                 return LibcType.DYNAMIC_MUSL
             if found_glibc:
                 return LibcType.DYNAMIC_GLIBC
-            raise Exception(f"Foind a dynamic binary without a libc: {elf.stream.name!r}")
+            raise Exception(f"Found a dynamic binary without a libc: {elf.stream.name!r}")
 
         # This symbol exists in both musl and glibc, and is even used by musl to recognize a DSO as a libc.
         # They even comment that it works on both musl and glibc.


### PR DESCRIPTION
Adds `get_libc_type` function to `elf.py`, it distinguishes between dynamic glibc/musl and for static - between libc existing an not existing.
It is harder to distinguish between musl/glibc in static binaries and technically, not really needed for our use cases.

I am 50/50 about splitting it to `get_dynamic_libc_type` and `is_static_libc` that just do their respective parts, lmk what you think.

As an aside - we really need to move this to a class so we don't need to re-read the elf for each function. We can keep the global functions as a convenience wrapper. Specifically - `get_libc_type` reads the elf twice, lmk if you want me to do the refactor to a class right now to avoid this.