### PR TITLE
lint: Avoid using binaries from outside the venv

### DIFF
--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -9,7 +9,6 @@ from typing import Optional, cast
 from elftools.elf.elffile import ELFError, ELFFile  # type: ignore
 from elftools.elf.sections import NoteSection  # type: ignore
 
-
 __all__ = ["ELFError"]
 
 

--- a/lint.sh
+++ b/lint.sh
@@ -15,7 +15,7 @@ fi
 # see also isort --skip and flake8 config.
 EXCLUDE_RE='.venv|venv|build|granulate_utils/generated'
 
-isort --settings-path .isort.cfg --skip granulate_utils/generated --skip venv --skip .venv --skip build .
-black --line-length 120 $check_arg --exclude $EXCLUDE_RE .
-flake8 --config .flake8  --exclude $(echo $EXCLUDE_RE | tr '|' ',') .
-mypy --exclude $EXCLUDE_RE .
+python3 -m isort --settings-path .isort.cfg --skip granulate_utils/generated --skip venv --skip .venv --skip build .
+python3 -m black --line-length 120 $check_arg --exclude $EXCLUDE_RE .
+python3 -m flake8 --config .flake8  --exclude $(echo $EXCLUDE_RE | tr '|' ',') .
+python3 -m mypy --exclude $EXCLUDE_RE .

--- a/lint.sh
+++ b/lint.sh
@@ -15,7 +15,7 @@ fi
 # see also isort --skip and flake8 config.
 EXCLUDE_RE='.venv|venv|build|granulate_utils/generated'
 
-python3 -m isort --settings-path .isort.cfg --skip granulate_utils/generated --skip venv --skip .venv --skip build .
+python3 -m isort --settings-path .isort.cfg $check_arg --skip granulate_utils/generated --skip venv --skip .venv --skip build .
 python3 -m black --line-length 120 $check_arg --exclude $EXCLUDE_RE .
 python3 -m flake8 --config .flake8  --exclude $(echo $EXCLUDE_RE | tr '|' ',') .
 python3 -m mypy --exclude $EXCLUDE_RE .


### PR DESCRIPTION
To avoid the case of someone creating a venv but forgetting to install `dev-requirements.txt` inside and then running mypy/isort/black from outside of the venv - use `python3 -m foo` instead of `foo` for all linters