### PR TITLE
Add wrapper for catching FileNotFound Exception

### DIFF
--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -30,20 +30,14 @@ def raise_nosuchprocess(func: Callable[P, R]) -> Callable[P, R]:
                 if e.filename.split("/")[2].isalnum():
                     # Take pid from /proc/{pid}/*
                     pid = int(e.filename.split("/")[2])
+                    # Check if number from /proc/{pid} is actually a pid number
                     with open("/proc/sys/kernel/pid_max") as pid_max_file:
                         pid_max = int(pid_max_file.read())
                     if pid <= pid_max:
                         # Check if pid is running
-                        if psutil.pid_exists(pid):
-                            raise e
-                        else:
+                        if not psutil.pid_exists(pid):
                             raise psutil.NoSuchProcess(pid)
-                    else:
-                        raise e
-                else:
-                    raise e
-            else:
-                raise e
+            raise e
     return inner
 
 

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -37,6 +37,7 @@ def raise_nosuchprocess(func: Callable[P, R]) -> Callable[P, R]:
                         if not psutil.pid_exists(pid):
                             raise psutil.NoSuchProcess(pid)
             raise e
+
     return inner
 
 

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -18,7 +18,7 @@ def catch_filenotfound(func):
         try:
             func(*args, **kwargs)
         except FileNotFoundError as e:
-            if ("/proc/" in e.filename):
+            if (e.filename.startswith("/proc/")):
                 # Take pid from /proc/{pid}/*
                 pid = e.filename.split("/")[2]
                 raise psutil.NoSuchProcess(pid)

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -4,14 +4,13 @@
 #
 
 import hashlib
-import psutil
-
-from typing import Callable, Optional, cast, TypeVar
-from typing_extensions import ParamSpec
 from functools import wraps
+from typing import Callable, Optional, TypeVar, cast
 
+import psutil
 from elftools.elf.elffile import ELFError, ELFFile  # type: ignore
 from elftools.elf.sections import NoteSection  # type: ignore
+from typing_extensions import ParamSpec
 
 __all__ = ["ELFError"]
 


### PR DESCRIPTION
It wraps function get_elf_id(), if that function throws FileNotFound exception then wrapper checks if not found file is /proc/{pid}/*, if it is, wrapper changes exception to NoSuchProcess.

Connected to: https://github.com/Granulate/gprofiler/issues/503