### PR TITLE
Use read_proc_file in get_cgroups()

### DIFF
--- a/granulate_utils/linux/cgroups/base_cgroup.py
+++ b/granulate_utils/linux/cgroups/base_cgroup.py
@@ -3,7 +3,6 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
-import os
 from pathlib import Path
 from typing import List, Mapping, Optional
 
@@ -30,7 +29,7 @@ class BaseCgroup:
         # "/proc/$PID/cgroup" lists a process's cgroup membership.  If legacy
         # cgroup is in use in the system, this file may contain multiple lines, one for each hierarchy.
         # The entry for cgroup v2 is always in the format "0::$PATH"::
-        if len(get_cgroups(os.getpid())) == 1:
+        if len(get_cgroups()) == 1:
             raise UnsupportedCGroupV2()
 
     @property
@@ -38,7 +37,7 @@ class BaseCgroup:
         raise NotImplementedError
 
     def _get_cgroup(self) -> str:
-        hierarchy_details = get_cgroups(os.getpid())
+        hierarchy_details = get_cgroups()
         for line in hierarchy_details:
             if self.subsystem in line[1]:
                 return line[2]

--- a/granulate_utils/linux/containers.py
+++ b/granulate_utils/linux/containers.py
@@ -4,7 +4,7 @@
 #
 
 import re
-from typing import Optional, Union
+from typing import Optional
 
 from psutil import Process
 
@@ -18,13 +18,12 @@ from granulate_utils.linux import cgroups
 CONTAINER_ID_PATTERN = re.compile(r"[a-f0-9]{64}")
 
 
-def get_process_container_id(process: Union[int, Process]) -> Optional[str]:
+def get_process_container_id(process: Process) -> Optional[str]:
     """
     Gets the container ID of a running process, or None if not in a container.
     :raises NoSuchProcess: If the process doesn't or no longer exists
     """
-    pid = process if isinstance(process, int) else process.pid
-    for _, _, cgpath in cgroups.get_cgroups(pid):
+    for _, _, cgpath in cgroups.get_cgroups(process):
         found = CONTAINER_ID_PATTERN.findall(cgpath)
         if found:
             return found[-1]


### PR DESCRIPTION
1. Updates `get_cgroups()` to use `read_proc_file` to catch errors better.
2. Removes ability to specify plain int pid to `get_process_container_id`, to force users to rely on `psutil.Process` at all times. (To reap the advantages of `psutil.Process` it must be used at all times, as early as possible.)
3. Makes `get_cgroups()` default to getting the cgroups of the current process if the parameter is not given. This is a shorthand for `get_cgroups(os.getpid())` which appears a couple times in the code.