### PR TITLE
Golang removed process_exe usage

### DIFF
--- a/granulate_utils/golang.py
+++ b/granulate_utils/golang.py
@@ -10,7 +10,6 @@ from typing import Optional
 from psutil import NoSuchProcess, Process
 
 from granulate_utils.linux.elf import read_elf_symbol, read_elf_va
-from granulate_utils.linux.process import process_exe
 
 
 def is_golang_process(process: Process) -> bool:

--- a/granulate_utils/golang.py
+++ b/granulate_utils/golang.py
@@ -19,7 +19,7 @@ def is_golang_process(process: Process) -> bool:
 
 @functools.lru_cache(maxsize=4096)
 def get_process_golang_version(process: Process) -> Optional[str]:
-    elf_path = process_exe(process)
+    elf_path = f"/proc/{process.pid}/exe"
     try:
         symbol_data = read_elf_symbol(elf_path, "runtime.buildVersion", 16)
     except FileNotFoundError:


### PR DESCRIPTION
`process_exe` resolves links. It fails path access inside dockers.