### PR TITLE
Added is_kernel_process function and used it in golang and node runtimes

### DIFF
--- a/granulate_utils/golang.py
+++ b/granulate_utils/golang.py
@@ -14,7 +14,7 @@ from granulate_utils.linux.process import is_kernel_thread
 
 
 def is_golang_process(process: Process) -> bool:
-    return (not is_kernel_thread(process)) and (get_process_golang_version(process) is not None)
+    return not is_kernel_thread(process) and get_process_golang_version(process) is not None
 
 
 @functools.lru_cache(maxsize=4096)

--- a/granulate_utils/golang.py
+++ b/granulate_utils/golang.py
@@ -10,10 +10,11 @@ from typing import Optional
 from psutil import NoSuchProcess, Process
 
 from granulate_utils.linux.elf import read_elf_symbol, read_elf_va
+from granulate_utils.linux.process import is_kernel_thread
 
 
 def is_golang_process(process: Process) -> bool:
-    return get_process_golang_version(process) is not None
+    return (not is_kernel_thread(process)) and (get_process_golang_version(process) is not None)
 
 
 @functools.lru_cache(maxsize=4096)

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -83,7 +83,7 @@ def _read_process_auxv(process: psutil.Process, auxv_id: int) -> int:
     auxv = read_proc_file(process, "auxv")
 
     for i in range(0, len(auxv), _AUXV_ENTRY.size):
-        entry = auxv[i : i + _AUXV_ENTRY.size]
+        entry = auxv[i: i + _AUXV_ENTRY.size]
         id_, val = _AUXV_ENTRY.unpack(entry)
 
         if id_ == auxv_id:
@@ -128,3 +128,7 @@ def is_process_basename_matching(process: psutil.Process, basename_pattern: str)
         return True
 
     return False
+
+
+def is_kernel_thread(process: psutil.Process) -> bool:
+    return process.pid == 2 or process.ppid() == 2

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -83,7 +83,7 @@ def _read_process_auxv(process: psutil.Process, auxv_id: int) -> int:
     auxv = read_proc_file(process, "auxv")
 
     for i in range(0, len(auxv), _AUXV_ENTRY.size):
-        entry = auxv[i: i + _AUXV_ENTRY.size]
+        entry = auxv[i : i + _AUXV_ENTRY.size]
         id_, val = _AUXV_ENTRY.unpack(entry)
 
         if id_ == auxv_id:

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -131,4 +131,5 @@ def is_process_basename_matching(process: psutil.Process, basename_pattern: str)
 
 
 def is_kernel_thread(process: psutil.Process) -> bool:
+    # Kernel threads should be child of process with pid 2, or with pid 2.
     return process.pid == 2 or process.ppid() == 2

--- a/granulate_utils/node.py
+++ b/granulate_utils/node.py
@@ -5,8 +5,8 @@
 
 from psutil import Process
 
-from granulate_utils.linux.process import is_process_basename_matching
+from granulate_utils.linux.process import is_process_basename_matching, is_kernel_thread
 
 
 def is_node_process(process: Process) -> bool:
-    return is_process_basename_matching(process, r"^node$")
+    return (not is_kernel_thread(process)) and is_process_basename_matching(process, r"^node$")

--- a/granulate_utils/node.py
+++ b/granulate_utils/node.py
@@ -5,7 +5,7 @@
 
 from psutil import Process
 
-from granulate_utils.linux.process import is_process_basename_matching, is_kernel_thread
+from granulate_utils.linux.process import is_kernel_thread, is_process_basename_matching
 
 
 def is_node_process(process: Process) -> bool:

--- a/granulate_utils/node.py
+++ b/granulate_utils/node.py
@@ -9,4 +9,4 @@ from granulate_utils.linux.process import is_kernel_thread, is_process_basename_
 
 
 def is_node_process(process: Process) -> bool:
-    return (not is_kernel_thread(process)) and is_process_basename_matching(process, r"^node$")
+    return not is_kernel_thread(process) and is_process_basename_matching(process, r"^node$")


### PR DESCRIPTION
The purpose of this PR is to avoid checking if kernel threads are golang/node processes.