### PR TITLE
granulate utils: fix process argv0 match check

### DIFF
--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -124,7 +124,7 @@ def is_process_basename_matching(process: psutil.Process, basename_pattern: str)
 
     # process was executed AS basename (but has different exe name)
     cmd = process.cmdline()
-    if len(cmd) > 0 and re.match(basename_pattern, cmd[0]):
+    if len(cmd) > 0 and re.match(basename_pattern, os.path.basename(cmd[0])):
         return True
 
     return False


### PR DESCRIPTION
When processes have been run with full path as argv0 - for example `/usr/bin/java` the function returned False on real true cases