### PR TITLE
granulate_utils: Handle unlimited cgroup quota

### DIFF
--- a/granulate_utils/linux/cgroups/cpu_cgroup.py
+++ b/granulate_utils/linux/cgroups/cpu_cgroup.py
@@ -19,7 +19,9 @@ class CpuCgroup(BaseCgroup):
 
     def get_cpu_limit_cores(self) -> float:
         period = int(self.read_from_control_file(self.cfs_period_us))
-        return int(self.read_from_control_file(self.cfs_quota_us)) / period
+        quota = int(self.read_from_control_file(self.cfs_quota_us))
+        # if quota is set to -1 it means this cgroup is unlimited
+        return quota / period if quota != -1 else -1.0
 
     def reset_cpu_limit(self) -> None:
         self.write_to_control_file(self.cfs_quota_us, "-1")

--- a/tests/granulate_utils/test_cgroups.py
+++ b/tests/granulate_utils/test_cgroups.py
@@ -4,15 +4,15 @@ from unittest.mock import patch
 from granulate_utils.linux.cgroups.cpu_cgroup import CpuCgroup
 
 
-def wrap_read_from_control_file(mapping: Dict[str, str]):
-    def func(tunable_name: str):
+def wrap_read_from_control_file(mapping: Dict[str, str]) -> Callable:
+    def func(tunable_name: str) -> str:
         return mapping[tunable_name]
 
     return func
 
 
 @patch("granulate_utils.linux.cgroups.cpu_cgroup.BaseCgroup.__init__", return_value=None)
-def test_get_cpu_limit_cores(base_group_mock: Callable):
+def test_get_cpu_limit_cores(base_group_mock: Callable) -> None:
     cpucgroup = CpuCgroup()
     with patch.object(
         cpucgroup,

--- a/tests/granulate_utils/test_cgroups.py
+++ b/tests/granulate_utils/test_cgroups.py
@@ -1,39 +1,28 @@
-from typing import Callable, Dict
+from typing import Callable
 from unittest.mock import patch
 
 from granulate_utils.linux.cgroups.cpu_cgroup import CpuCgroup
 
 
-def wrap_read_from_control_file(mapping: Dict[str, str]) -> Callable:
-    def func(tunable_name: str) -> str:
-        return mapping[tunable_name]
-
-    return func
-
-
-@patch("granulate_utils.linux.cgroups.cpu_cgroup.BaseCgroup.__init__", return_value=None)
+@patch("granulate_utils.linux.cgroups.cpu_cgroup.BaseCgroup._verify_preconditions", return_value=None)
 def test_get_cpu_limit_cores(base_group_mock: Callable) -> None:
     cpucgroup = CpuCgroup()
     with patch.object(
         cpucgroup,
         "read_from_control_file",
-        wrap_read_from_control_file(
-            {
-                CpuCgroup.cfs_period_us: "100",
-                CpuCgroup.cfs_quota_us: "50",
-            }
-        ),
+        {
+            CpuCgroup.cfs_period_us: "100",
+            CpuCgroup.cfs_quota_us: "50",
+        }.__getitem__,
     ):
         assert cpucgroup.get_cpu_limit_cores() == 0.5
 
     with patch.object(
         cpucgroup,
         "read_from_control_file",
-        wrap_read_from_control_file(
-            {
-                CpuCgroup.cfs_period_us: "100",
-                CpuCgroup.cfs_quota_us: "-1",
-            }
-        ),
+        {
+            CpuCgroup.cfs_period_us: "100",
+            CpuCgroup.cfs_quota_us: "-1",
+        }.__getitem__,
     ):
         assert cpucgroup.get_cpu_limit_cores() == -1.0

--- a/tests/granulate_utils/test_cgroups.py
+++ b/tests/granulate_utils/test_cgroups.py
@@ -1,0 +1,39 @@
+from typing import Callable, Dict
+from unittest.mock import patch
+
+from granulate_utils.linux.cgroups.cpu_cgroup import CpuCgroup
+
+
+def wrap_read_from_control_file(mapping: Dict[str, str]):
+    def func(tunable_name: str):
+        return mapping[tunable_name]
+
+    return func
+
+
+@patch("granulate_utils.linux.cgroups.cpu_cgroup.BaseCgroup.__init__", return_value=None)
+def test_get_cpu_limit_cores(base_group_mock: Callable):
+    cpucgroup = CpuCgroup()
+    with patch.object(
+        cpucgroup,
+        "read_from_control_file",
+        wrap_read_from_control_file(
+            {
+                CpuCgroup.cfs_period_us: "100",
+                CpuCgroup.cfs_quota_us: "50",
+            }
+        ),
+    ):
+        assert cpucgroup.get_cpu_limit_cores() == 0.5
+
+    with patch.object(
+        cpucgroup,
+        "read_from_control_file",
+        wrap_read_from_control_file(
+            {
+                CpuCgroup.cfs_period_us: "100",
+                CpuCgroup.cfs_quota_us: "-1",
+            }
+        ),
+    ):
+        assert cpucgroup.get_cpu_limit_cores() == -1.0


### PR DESCRIPTION
Take into account that a cgroup can be unlimited (`cfs_quota_us` is set to -1).