### PR TITLE
Drop Python 3.6, 3.7 support

### DIFF
--- a/.github/workflows/glogger.yml
+++ b/.github/workflows/glogger.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Granulate's shared Python utilities
 
+Supports Python 3.8+.
 
 ## Testing
 


### PR DESCRIPTION
With https://github.com/Granulate/gprofiler/pull/597 merged, we no longer use 3.6 (and nothing uses 3.7). Now the minimum version is 3.8.

I will give some time to the version based on https://github.com/Granulate/gprofiler/pull/597 to run (to make sure we don't go back to 3.6) before I change it.