### PR TITLE
normpath-resolve-proc-root-links

### DIFF
--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -82,7 +82,7 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
                 next_path = os.path.join(os.path.dirname(next_path), link)
         path = next_path
 
-    return path
+    return os.path.normpath(path)
 
 
 def get_process_nspid(process: Union[Process, int]) -> int:


### PR DESCRIPTION
returnes path may contain relative symlinks which might contain `.` or `..`, `normpath` "eliminates" them by "resolving" these simple built in links