### PR TITLE
cgroups: Write to specific CGroup only

### DIFF
--- a/granulate_utils/linux/cgroups/cpu_cgroup.py
+++ b/granulate_utils/linux/cgroups/cpu_cgroup.py
@@ -2,6 +2,7 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
+from pathlib import Path
 from typing import Dict
 
 from granulate_utils.linux.cgroups.base_cgroup import BaseCgroup
@@ -13,9 +14,9 @@ class CpuCgroup(BaseCgroup):
     cfs_quota_us = "cpu.cfs_quota_us"
     cpu_stat = "cpu.stat"
 
-    def set_cpu_limit_cores(self, cores: float) -> None:
-        period = int(self.read_from_control_file(self.cfs_period_us))
-        self.write_to_control_file(self.cfs_quota_us, str(int(period * cores)))
+    def set_cpu_limit_cores(self, controller_path: Path, cores: float) -> None:
+        period = int(self.read_from_control_file(self.cfs_period_us, controller_path))
+        self.write_to_control_file(controller_path, self.cfs_quota_us, str(int(period * cores)))
 
     def get_cpu_limit_cores(self) -> float:
         period = int(self.read_from_control_file(self.cfs_period_us))
@@ -23,8 +24,8 @@ class CpuCgroup(BaseCgroup):
         # if quota is set to -1 it means this cgroup is unlimited
         return quota / period if quota != -1 else -1.0
 
-    def reset_cpu_limit(self) -> None:
-        self.write_to_control_file(self.cfs_quota_us, "-1")
+    def reset_cpu_limit(self, controller_path: Path) -> None:
+        self.write_to_control_file(controller_path, self.cfs_quota_us, "-1")
 
     def get_stat(self) -> Dict[str, int]:
         stat_text = self.read_from_control_file(self.cpu_stat)

--- a/granulate_utils/linux/cgroups/memory_cgroup.py
+++ b/granulate_utils/linux/cgroups/memory_cgroup.py
@@ -3,6 +3,8 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
+from pathlib import Path
+
 from granulate_utils.linux.cgroups.base_cgroup import BaseCgroup
 
 
@@ -22,23 +24,23 @@ class MemoryCgroup(BaseCgroup):
     def get_usage_in_bytes(self) -> int:
         return int(self.read_from_control_file(self.usage_in_bytes))
 
-    def _set_memsw_limit_in_bytes(self, limit: int) -> None:
+    def _set_memsw_limit_in_bytes(self, controller_path: Path, limit: int) -> None:
         try:
-            self.write_to_control_file(self.memsw_limit_in_bytes, str(limit))
+            self.write_to_control_file(controller_path, self.memsw_limit_in_bytes, str(limit))
         except PermissionError:
             # if swap extension is not enabled (CONFIG_MEMCG_SWAP) this file doesn't exist
             # and PermissionError is thrown (since it can't be created)
             pass
 
-    def set_limit_in_bytes(self, limit: int) -> None:
+    def set_limit_in_bytes(self, controller_path: Path, limit: int) -> None:
         # in case memsw.limit_in_bytes file exists we need to reset it in order to
         # change limit_in_bytes in case it's smaller than memsw.limit_in_bytes
-        self._set_memsw_limit_in_bytes(-1)
-        self.write_to_control_file(self.limit_in_bytes, str(limit))
+        self._set_memsw_limit_in_bytes(controller_path, -1)
+        self.write_to_control_file(controller_path, self.limit_in_bytes, str(limit))
 
         # memsw.limit_in_bytes is already set to -1
         if limit != -1:
-            self._set_memsw_limit_in_bytes(limit)
+            self._set_memsw_limit_in_bytes(controller_path, limit)
 
-    def reset_memory_limit(self) -> None:
-        self.set_limit_in_bytes(-1)
+    def reset_memory_limit(self, controller_path: Path) -> None:
+        self.set_limit_in_bytes(controller_path, -1)


### PR DESCRIPTION
When setting attributes for controllers, force passing a full path for the controller instead of writing to current process controller.