### PR TITLE
updated logging_kwargs template

### DIFF
--- a/glogger/extra_adapter.py
+++ b/glogger/extra_adapter.py
@@ -39,6 +39,5 @@ class ExtraAdapter(logging.LoggerAdapter):
             logging_kwargs["extra"] = extra
 
         extra = self.get_extra(**logging_kwargs)
-        # Retain all extras as attributes on the record, and add "extra" attribute that contains all the extras:
-        logging_kwargs.update({"extra": {**extra, "extra": extra}})
+        logging_kwargs.update({"extra": dict(extra=extra)})
         return msg, logging_kwargs

--- a/tests/glogger/test_extra_adapter.py
+++ b/tests/glogger/test_extra_adapter.py
@@ -25,7 +25,6 @@ def test_logging_kwargs_not_present_in_extra(caplog):
     caplog.set_level(logging.INFO)
     ExtraAdapter(logging.getLogger()).info("test message", stacklevel=8, stack_info=True, test=6)
     record = caplog.records[0]
-    assert record.test == 6
     assert hasattr(record, "extra")
     assert record.extra == dict(test=6)
 


### PR DESCRIPTION
## Use case
if you try to pass the following extra params : 
self.log(DEBUG, msg, *args, **kwargs) -> kwargs = {'name': 'pubsub', 'namespace_id': 2, 'hash': '123', 'old_hash': '567'}
you will get the following error:
"Attempt to overwrite name in LogRecord"
<img width="652" alt="image" src="https://user-images.githubusercontent.com/16275232/211940027-bcbd35b7-fb7f-42b7-89f6-29742cb8f43c.png">

## Solution
if we would like to enable sending extra param keys from the following list
‘name’, ‘msg’, ‘args’, ‘levelname’, ‘levelno’, ‘pathname’, ‘filename’, ‘module’, ‘exc_info’, ‘exc_text’, ‘stack_info’, ‘lineno’, ‘funcName’, ‘created’, ‘msecs’, ‘relativeCreated’, ‘thread’, 
the extra param should not be at the same level of those logRecord keys