### PR TITLE
Migrate metrics code from gprofiler

### DIFF
--- a/granulate_utils/metrics/__init__.py
+++ b/granulate_utils/metrics/__init__.py
@@ -1,4 +1,41 @@
 from typing import Any, Dict
+from urllib.parse import urljoin
+
+import requests
+
+
+def rest_request_to_json(address: str, object_path: str, *args: Any, **kwargs: Any) -> Any:
+    """
+    Query the given URL and return the JSON response
+    """
+    return rest_request(address, object_path, *args, **kwargs).json()
+
+
+def rest_request(url: str, object_path: str, *args: Any, **kwargs: Any) -> requests.Response:
+    """
+    Query the given URL and return the response
+    """
+    if object_path:
+        url = join_url_dir(url, object_path)
+
+    # Add args to the url
+    if args:
+        for directory in args:
+            url = join_url_dir(url, directory)
+
+    response = requests.get(url, params={k: v for k, v in kwargs.items() if v is not None}, timeout=3)
+    response.raise_for_status()
+    return response
+
+
+def join_url_dir(url: str, *args: Any) -> str:
+    """
+    Join a URL with multiple directories
+    """
+    for path in args:
+        url = url.rstrip("/") + "/"
+        url = urljoin(url, path.lstrip("/"))
+    return url
 
 
 def set_individual_metric(

--- a/granulate_utils/metrics/__init__.py
+++ b/granulate_utils/metrics/__init__.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict
+
+
+def set_individual_metric(
+    collected_metrics: Dict[str, Dict[str, Any]], name: str, value: Any, labels: Dict[str, str]
+) -> None:
+    """
+    Add a metric to collected_metrics with labels in {name, value, labels} format.
+    Metric is only added if the value is not None.
+    """
+    if name not in collected_metrics and value is not None:
+        collected_metrics[name] = {
+            "name": name,
+            "value": value,
+            "labels": labels,
+        }
+
+
+def set_metrics_from_json(
+    collected_metrics: Dict[str, Dict[str, Any]],
+    labels: Dict[str, str],
+    metrics_json: Dict[Any, Any],
+    metrics: Dict[str, str],
+) -> None:
+    """
+    Extract metrics values from JSON response and add to collected_metrics in {name, value, labels} format.
+    """
+    if metrics_json is None:
+        return
+
+    for field_name, metric_name in metrics.items():
+        metric_value = metrics_json.get(field_name)
+        set_individual_metric(collected_metrics, metric_name, metric_value, labels)

--- a/granulate_utils/metrics/spark.py
+++ b/granulate_utils/metrics/spark.py
@@ -1,0 +1,89 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+SPARK_APPS_PATH = "api/v1/applications"
+
+SPARK_JOB_METRICS = {
+    metric: f"spark_job_{metric}"
+    for metric in (
+        "numActiveTasks",
+        "numActiveStages",
+    )
+}
+SPARK_JOB_DIFF_METRICS = {
+    metric: f"spark_job_diff_{metric}"
+    for metric in (
+        "numTasks",
+        "numCompletedTasks",
+        "numSkippedTasks",
+        "numFailedTasks",
+        "numCompletedStages",
+        "numSkippedStages",
+        "numFailedStages",
+    )
+}
+SPARK_STAGE_METRICS = {
+    metric: f"spark_stage_{metric}"
+    for metric in (
+        "numActiveTasks",
+        "numCompleteTasks",
+        "numFailedTasks",
+        "executorRunTime",
+        "inputBytes",
+        "inputRecords",
+        "outputBytes",
+        "outputRecords",
+        "shuffleReadBytes",
+        "shuffleReadRecords",
+        "shuffleWriteBytes",
+        "shuffleWriteRecords",
+        "memoryBytesSpilled",
+        "diskBytesSpilled",
+    )
+}
+SPARK_RDD_METRICS = {
+    metric: f"spark_rdd_{metric}" for metric in ("numPartitions", "numCachedPartitions", "memoryUsed", "diskUsed")
+}
+SPARK_TASK_SUMMARY_METRICS = {
+    metric: f"spark_stage_tasks_summary_{metric}"
+    for metric in (
+        "executorDeserializeTime",
+        "executorDeserializeCpuTime",
+        "executorRunTime",
+        "executorCpuTime",
+        "resultSize",
+        "jvmGcTime",
+        "resultSerializationTime",
+        "gettingResultTime",
+        "schedulerDelay",
+        "peakExecutionMemory",
+        "memoryBytesSpilled",
+        "diskBytesSpilled",
+    )
+}
+SPARK_STREAMING_STATISTICS_METRICS = {
+    metric: f"spark_streaming_statistics_{metric}"
+    for metric in (
+        "avgInputRate",
+        "avgProcessingTime",
+        "avgSchedulingDelay",
+        "avgTotalDelay",
+        "batchDuration",
+        "numActiveBatches",
+        "numActiveReceivers",
+        "numInactiveReceivers",
+        "numProcessedRecords",
+        "numReceivedRecords",
+        "numReceivers",
+        "numRetainedCompletedBatches",
+        "numTotalCompletedBatches",
+    )
+}
+SPARK_STRUCTURED_STREAMING_METRICS = {
+    "inputRate-total": "spark_structured_streaming_input_rate",
+    "latency": "spark_structured_streaming_latency",
+    "processingRate-total": "spark_structured_streaming_processing_rate",
+    "states-rowsTotal": "spark_structured_streaming_rows_count",
+    "states-usedBytes": "spark_structured_streaming_used_bytes",
+}

--- a/granulate_utils/metrics/yarn.py
+++ b/granulate_utils/metrics/yarn.py
@@ -1,0 +1,49 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+YARN_CLUSTER_PATH = "ws/v1/cluster/metrics"
+YARN_NODES_PATH = "ws/v1/cluster/nodes"
+
+YARN_CLUSTER_METRICS = {
+    metric: f"yarn_cluster_{metric}"
+    for metric in (
+        "appsSubmitted",
+        "appsCompleted",
+        "appsPending",
+        "appsRunning",
+        "appsFailed",
+        "appsKilled",
+        "totalMB",
+        "availableMB",
+        "allocatedMB",
+        "availableVirtualCores",
+        "allocatedVirtualCores",
+        "totalNodes",
+        "activeNodes",
+        "lostNodes",
+        "decommissioningNodes",
+        "decommissionedNodes",
+        "rebootedNodes",
+        "shutdownNodes",
+        "unhealthyNodes",
+        "containersAllocated",
+        "containersPending",
+    )
+}
+YARN_NODES_METRICS = {
+    metric: f"yarn_node_{metric}"
+    for metric in (
+        "numContainers",
+        "usedMemoryMB",
+        "availMemoryMB",
+        "usedVirtualCores",
+        "availableVirtualCores",
+        "nodePhysicalMemoryMB",
+        "nodeVirtualMemoryMB",
+        "nodeCPUUsage",
+        "containersCPUUsage",
+        "aggregatedContainersPhysicalMemoryMB",
+        "aggregatedContainersVirtualMemoryMB",
+    )
+}

--- a/granulate_utils/metrics/yarn.py
+++ b/granulate_utils/metrics/yarn.py
@@ -2,6 +2,10 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
+from typing import Any, Dict, Generator
+
+from granulate_utils.metrics import rest_request_to_json, set_metrics_from_json
+
 YARN_CLUSTER_PATH = "ws/v1/cluster/metrics"
 YARN_NODES_PATH = "ws/v1/cluster/nodes"
 
@@ -47,3 +51,36 @@ YARN_NODES_METRICS = {
         "aggregatedContainersVirtualMemoryMB",
     )
 }
+
+
+class YarnCollector:
+    def __init__(self, master_address: str, logger: Any) -> None:
+        self.master_address = master_address
+        self.logger = logger
+
+    def collect(self) -> Generator[Dict[str, Any], None, None]:
+        collected_metrics: Dict[str, Dict[str, Any]] = {}
+        self._cluster_metrics(collected_metrics)
+        self._nodes_metrics(collected_metrics)
+        yield from collected_metrics.values()
+
+    def _cluster_metrics(self, collected_metrics: Dict[str, Dict[str, Any]]) -> None:
+        try:
+            metrics_json = rest_request_to_json(self.master_address, YARN_CLUSTER_PATH)
+            if metrics_json.get("clusterMetrics") is not None:
+                set_metrics_from_json(collected_metrics, {}, metrics_json["clusterMetrics"], YARN_CLUSTER_METRICS)
+        except Exception:
+            self.logger.exception("Could not gather yarn cluster metrics")
+
+    def _nodes_metrics(self, collected_metrics: Dict[str, Dict[str, Any]]) -> None:
+        try:
+            metrics_json = rest_request_to_json(self.master_address, YARN_NODES_PATH, states="RUNNING")
+            running_nodes = metrics_json.get("nodes", {}).get("node", {})
+            for node in running_nodes:
+                for metric, value in node.get("resourceUtilization", {}).items():
+                    node[metric] = value  # this will create all relevant metrics under same dictionary
+
+                labels = {"node_hostname": node["nodeHostName"]}
+                set_metrics_from_json(collected_metrics, labels, node, YARN_NODES_METRICS)
+        except Exception:
+            self.logger.exception("Could not gather yarn nodes metrics")


### PR DESCRIPTION
Mostly deals with YARN metrics collection as in gProfiler. Migrated the YARN+Spark URL paths and metrics names, as well as the YARN collection logic. Will add Spark collection after a bit more cleanup.