### PR TITLE
granulate_utils: Improve cloud info fetching performance

### DIFF
--- a/.github/workflows/granulate-utils.yml
+++ b/.github/workflows/granulate-utils.yml
@@ -32,12 +32,20 @@ jobs:
       run: ./lint.sh --ci
 
   test:
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/setup-python@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
 
     - name: Checkout Code
       uses: actions/checkout@v2

--- a/granulate_utils/futures.py
+++ b/granulate_utils/futures.py
@@ -1,0 +1,29 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed, _base, Future
+from contextlib import contextmanager
+from typing import Callable, Collection, Generator, TypeVar
+
+T = TypeVar('T')
+
+
+@contextmanager
+def wrap_thread_pool(pool: ThreadPoolExecutor) -> Generator[ThreadPoolExecutor, None, None]:
+    try:
+        yield pool
+    except _base.TimeoutError as e:
+        raise TimeoutError(*e.args) from e
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+
+def call_in_parallel(callables: Collection[Callable[[], T]], timeout: float, max_threads: int = 10) -> Generator[Future[T], None, None]:
+    """
+    Call the given callables in parallel and generate their futures in correspondence to their finishing order.
+
+    Please note that the underlying threads are not daemonized and this function does not wait for all calls to finish,
+    this means that if the caller does not invoke future.result() for all of the calls - the other callables will continue executing in the background (potentially preventing the process from closing).
+    Therefore it's important to make sure the callables themselves have timeouts.
+    """
+    with wrap_thread_pool(ThreadPoolExecutor(max_workers=min(len(callables), max_threads))) as pool:
+        futures = {pool.submit(callable) for callable in callables}
+        for completed in as_completed(futures, timeout):
+            yield completed

--- a/granulate_utils/futures.py
+++ b/granulate_utils/futures.py
@@ -1,8 +1,6 @@
 from concurrent.futures import Future, ThreadPoolExecutor, _base, as_completed
 from contextlib import contextmanager
-from typing import Callable, Collection, Generator, TypeVar
-
-T = TypeVar("T")
+from typing import Callable, Collection, Generator, Any
 
 
 @contextmanager
@@ -19,8 +17,8 @@ def wrap_thread_pool(pool: ThreadPoolExecutor) -> Generator[ThreadPoolExecutor, 
 
 
 def call_in_parallel(
-    callables: Collection[Callable[[], T]], timeout: float, max_threads: int = 10
-) -> Generator[Future[T], None, None]:
+    callables: Collection[Callable[[], Any]], timeout: float, max_threads: int = 10
+) -> Generator[Future, None, None]:
     """
     Call the given callables in parallel and generate their futures in correspondence to their finishing order.
 

--- a/granulate_utils/futures.py
+++ b/granulate_utils/futures.py
@@ -10,6 +10,9 @@ def wrap_thread_pool(pool: ThreadPoolExecutor) -> Generator[ThreadPoolExecutor, 
     try:
         yield pool
     except _base.TimeoutError as e:
+        # Translate _base.TimeoutError to be a standard TimeoutError, this was only fixed in python 3.11
+        # so we achieve here the same behavior for older python versions
+        # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.TimeoutError
         raise TimeoutError(*e.args) from e
     finally:
         pool.shutdown(wait=False)
@@ -21,10 +24,13 @@ def call_in_parallel(
     """
     Call the given callables in parallel and generate their futures in correspondence to their finishing order.
 
-    Please note that the underlying threads are not daemonized and this function does not wait for all calls to finish,
-    this means that if the caller does not invoke future.result() for all of the calls -
-    the other callables will continue executing in the background (potentially preventing the process from closing).
+    Note that the underlying threads are not daemonized and this function does not wait for all calls to finish,
+    this means that if the caller does not iterate through all futures -
+    some callables may continue executing in the background (potentially preventing the process from closing).
     Therefore it's important to make sure the callables themselves have timeouts.
+
+    :raises TimeoutError: If __next__() is called and the result isn't available after timeout seconds
+    from the call to call_in_parallel()
     """
     with wrap_thread_pool(ThreadPoolExecutor(max_workers=min(len(callables), max_threads))) as pool:
         futures = {pool.submit(callable) for callable in callables}

--- a/granulate_utils/futures.py
+++ b/granulate_utils/futures.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future, ThreadPoolExecutor, _base, as_completed
 from contextlib import contextmanager
-from typing import Callable, Collection, Generator, Any
+from typing import Any, Callable, Collection, Generator
 
 
 @contextmanager

--- a/granulate_utils/futures.py
+++ b/granulate_utils/futures.py
@@ -1,3 +1,10 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+
+from __future__ import annotations
+
 from concurrent.futures import Future, ThreadPoolExecutor, _base, as_completed
 from contextlib import contextmanager
 from typing import Any, Callable, Collection, Generator

--- a/granulate_utils/futures.py
+++ b/granulate_utils/futures.py
@@ -12,7 +12,7 @@ def wrap_thread_pool(pool: ThreadPoolExecutor) -> Generator[ThreadPoolExecutor, 
     except _base.TimeoutError as e:
         raise TimeoutError(*e.args) from e
     finally:
-        pool.shutdown(wait=False, cancel_futures=True)
+        pool.shutdown(wait=False)
 
 
 def call_in_parallel(

--- a/granulate_utils/futures.py
+++ b/granulate_utils/futures.py
@@ -1,8 +1,8 @@
-from concurrent.futures import ThreadPoolExecutor, as_completed, _base, Future
+from concurrent.futures import Future, ThreadPoolExecutor, _base, as_completed
 from contextlib import contextmanager
 from typing import Callable, Collection, Generator, TypeVar
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 @contextmanager
@@ -15,12 +15,15 @@ def wrap_thread_pool(pool: ThreadPoolExecutor) -> Generator[ThreadPoolExecutor, 
         pool.shutdown(wait=False, cancel_futures=True)
 
 
-def call_in_parallel(callables: Collection[Callable[[], T]], timeout: float, max_threads: int = 10) -> Generator[Future[T], None, None]:
+def call_in_parallel(
+    callables: Collection[Callable[[], T]], timeout: float, max_threads: int = 10
+) -> Generator[Future[T], None, None]:
     """
     Call the given callables in parallel and generate their futures in correspondence to their finishing order.
 
     Please note that the underlying threads are not daemonized and this function does not wait for all calls to finish,
-    this means that if the caller does not invoke future.result() for all of the calls - the other callables will continue executing in the background (potentially preventing the process from closing).
+    this means that if the caller does not invoke future.result() for all of the calls -
+    the other callables will continue executing in the background (potentially preventing the process from closing).
     Therefore it's important to make sure the callables themselves have timeouts.
     """
     with wrap_thread_pool(ThreadPoolExecutor(max_workers=min(len(callables), max_threads))) as pool:

--- a/granulate_utils/metadata/cloud.py
+++ b/granulate_utils/metadata/cloud.py
@@ -6,7 +6,7 @@
 import logging
 from dataclasses import dataclass
 from http.client import NOT_FOUND
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 import requests
 from requests import Response
@@ -168,21 +168,21 @@ def get_static_cloud_instance_metadata(logger: Union[logging.LoggerAdapter, logg
     raised_exceptions: List[Exception] = []
     cloud_metadata_fetchers = [get_aws_metadata, get_gcp_metadata, get_azure_metadata]
 
-    def _fetch() -> Tuple[Optional[Metadata], List[Exception]]:
+    def _fetch() -> Optional[Metadata]:
         for future in call_in_parallel(cloud_metadata_fetchers, timeout=METADATA_REQUEST_TIMEOUT + 1):
             try:
                 response = future.result()
                 if response is not None:
-                    return response.__dict__, []
+                    return response.__dict__
             except (ConnectionError, BadResponseCode):
                 pass
             except Exception as exception:
                 raised_exceptions.append(exception)
 
-        return None, raised_exceptions
+        return None
 
     try:
-        metadata, raised_exceptions = run_in_ns(["net"], _fetch)
+        metadata = run_in_ns(["net"], _fetch)
         if metadata is not None:
             return metadata
     except TimeoutError as exception:

--- a/granulate_utils/metadata/cloud.py
+++ b/granulate_utils/metadata/cloud.py
@@ -168,7 +168,7 @@ def get_static_cloud_instance_metadata(logger: Union[logging.LoggerAdapter, logg
     def _fetch() -> Tuple[Optional[Metadata], List[Exception]]:
         cloud_metadata_fetchers = [get_aws_metadata, get_gcp_metadata, get_azure_metadata]
         raised_exceptions: List[Exception] = []
-        for future in call_in_parallel(cloud_metadata_fetchers, timeout=6):
+        for future in call_in_parallel(cloud_metadata_fetchers, timeout=METADATA_REQUEST_TIMEOUT + 1):
             try:
                 response = future.result()
                 if response is not None:

--- a/granulate_utils/metadata/cloud.py
+++ b/granulate_utils/metadata/cloud.py
@@ -13,9 +13,9 @@ from requests import Response
 from requests.exceptions import ConnectionError
 
 from granulate_utils.exceptions import BadResponseCode
+from granulate_utils.futures import call_in_parallel
 from granulate_utils.linux.ns import run_in_ns
 from granulate_utils.metadata import Metadata
-from granulate_utils.futures import call_in_parallel
 
 METADATA_REQUEST_TIMEOUT = 5
 

--- a/tests/granulate_utils/test_futures.py
+++ b/tests/granulate_utils/test_futures.py
@@ -1,0 +1,35 @@
+import time
+import pytest
+
+from granulate_utils.futures import call_in_parallel
+
+
+def wait(seconds: int) -> int:
+    time.sleep(seconds)
+    return seconds
+
+
+def test_return_first_result_sanity() -> None:
+    assert 1 == next(call_in_parallel((lambda: wait(1), lambda: wait(2), lambda: wait(3)), timeout=5)).result()
+    assert 1 == next(call_in_parallel((lambda: wait(3), lambda: wait(2), lambda: wait(1)), timeout=5)).result()
+    for i, future in enumerate(call_in_parallel((lambda: wait(0), lambda: wait(1), lambda: wait(2)), timeout=5)):
+        assert i == future.result()
+
+
+def test_return_first_result_timeout() -> None:
+    with pytest.raises(TimeoutError, match='futures unfinished'):
+        next(call_in_parallel((lambda: wait(2), lambda: wait(2)), timeout=1)).result()
+
+
+def test_return_first_result_exception_handling() -> None:
+    def throwing_first() -> None:
+        raise Exception('throwing')
+
+    with pytest.raises(Exception, match='throwing'):
+        next(call_in_parallel((throwing_first, lambda: wait(2)), timeout=5)).result()
+
+    def throwing_last() -> None:
+        time.sleep(2)
+        raise Exception('throwing')
+
+    assert 1 == next(call_in_parallel((throwing_last, lambda: wait(1)), timeout=5)).result()

--- a/tests/granulate_utils/test_futures.py
+++ b/tests/granulate_utils/test_futures.py
@@ -1,4 +1,5 @@
 import time
+
 import pytest
 
 from granulate_utils.futures import call_in_parallel
@@ -17,19 +18,19 @@ def test_return_first_result_sanity() -> None:
 
 
 def test_return_first_result_timeout() -> None:
-    with pytest.raises(TimeoutError, match='futures unfinished'):
+    with pytest.raises(TimeoutError, match="futures unfinished"):
         next(call_in_parallel((lambda: wait(2), lambda: wait(2)), timeout=1)).result()
 
 
 def test_return_first_result_exception_handling() -> None:
     def throwing_first() -> None:
-        raise Exception('throwing')
+        raise Exception("throwing")
 
-    with pytest.raises(Exception, match='throwing'):
+    with pytest.raises(Exception, match="throwing"):
         next(call_in_parallel((throwing_first, lambda: wait(2)), timeout=5)).result()
 
     def throwing_last() -> None:
         time.sleep(2)
-        raise Exception('throwing')
+        raise Exception("throwing")
 
     assert 1 == next(call_in_parallel((throwing_last, lambda: wait(1)), timeout=5)).result()

--- a/tests/granulate_utils/test_futures.py
+++ b/tests/granulate_utils/test_futures.py
@@ -34,3 +34,10 @@ def test_call_in_parallel_exception_handling() -> None:
         raise Exception("throwing")
 
     assert 1 == next(call_in_parallel((throwing_last, lambda: wait(1)), timeout=5)).result()
+
+    # Verify that result() is the one throwing and not __next__()
+    for i, future in enumerate(call_in_parallel((throwing_first, lambda: wait(1), throwing_last), timeout=5)):
+        try:
+            assert i == future.result()
+        except Exception:
+            assert i in (0, 2)

--- a/tests/granulate_utils/test_futures.py
+++ b/tests/granulate_utils/test_futures.py
@@ -10,19 +10,19 @@ def wait(seconds: int) -> int:
     return seconds
 
 
-def test_return_first_result_sanity() -> None:
+def test_call_in_parallel_sanity() -> None:
     assert 1 == next(call_in_parallel((lambda: wait(1), lambda: wait(2), lambda: wait(3)), timeout=5)).result()
     assert 1 == next(call_in_parallel((lambda: wait(3), lambda: wait(2), lambda: wait(1)), timeout=5)).result()
     for i, future in enumerate(call_in_parallel((lambda: wait(0), lambda: wait(1), lambda: wait(2)), timeout=5)):
         assert i == future.result()
 
 
-def test_return_first_result_timeout() -> None:
+def test_call_in_parallel_timeout() -> None:
     with pytest.raises(TimeoutError, match="futures unfinished"):
         next(call_in_parallel((lambda: wait(2), lambda: wait(2)), timeout=1)).result()
 
 
-def test_return_first_result_exception_handling() -> None:
+def test_call_in_parallel_exception_handling() -> None:
     def throwing_first() -> None:
         raise Exception("throwing")
 


### PR DESCRIPTION
* Add the `call_in_parallel` utility for convenience
* Use `call_in_parallel` in `get_static_cloud_instance_metadata` so we don't waste time if we're in the wrong cloud provider