### PR TITLE
Spark: removed spammy debug logs in discover()

### DIFF
--- a/granulate_utils/metrics/sampler.py
+++ b/granulate_utils/metrics/sampler.py
@@ -236,7 +236,6 @@ class BigDataSampler(Sampler):
         webapp_url = None
 
         if spark_master_process is None:
-            self._logger.debug("Could not find any spark master process (resource manager or spark master)")
             return None
 
         if "org.apache.hadoop.yarn.server.resourcemanager.ResourceManager" in spark_master_process.cmdline():
@@ -297,7 +296,6 @@ class BigDataSampler(Sampler):
             have_conf = True
 
         else:
-            self._logger.debug("Trying to guess cluster mode and master address")
             cluster_conf = self._guess_cluster_mode()
             if cluster_conf is not None:
                 master_address, self._cluster_mode = cluster_conf

--- a/granulate_utils/metrics/sampler.py
+++ b/granulate_utils/metrics/sampler.py
@@ -300,11 +300,6 @@ class BigDataSampler(Sampler):
             if cluster_conf is not None:
                 master_address, self._cluster_mode = cluster_conf
                 self._master_address = f"http://{master_address}"
-                self._logger.debug(
-                    "Guessed cluster mode and master address",
-                    cluster_mode=self._cluster_mode,
-                    master_address=self._master_address,
-                )
                 have_conf = True
 
         if have_conf:


### PR DESCRIPTION
currently, in gProfiler, `discover()` is invoked every 5 seconds 10 minutes.
in any case that gProfiler is installed on every instance in a cluster, the next logs will heavily appear for the first 10 minutes:
[Could not find any spark master process (resource manager or spark master)
](https://github.com/Granulate/granulate-utils/pull/145/files#diff-e8dd154b7df986eb768fe56114e039f44a244a6a5d75f464611aa95fcb21866fL239)[Trying to guess cluster mode and master address](https://github.com/Granulate/granulate-utils/pull/145/files#diff-e8dd154b7df986eb768fe56114e039f44a244a6a5d75f464611aa95fcb21866fL300)
also, removed the next log:
[Guessed cluster mode and master address](https://github.com/Granulate/granulate-utils/pull/145/files#diff-e8dd154b7df986eb768fe56114e039f44a244a6a5d75f464611aa95fcb21866fL305-L309)
which is a duplication of:
[Guessed settings](https://github.com/Granulate/granulate-utils/blob/d5c2dacba01e45f3534e038d9ccb65ea3ef8a48e/granulate_utils/metrics/sampler.py#L258)