### PR TITLE
add auth method params

### DIFF
--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -38,7 +38,7 @@ class Sender:
         server_address: str,
         *,
         scheme: str = "https",
-        auth_token_type: str = "",
+        auth_secret: str = "",
         send_interval: float = 30.0,
         send_threshold: float = 0.8,
         send_min_interval: float = 10.0,
@@ -50,7 +50,7 @@ class Sender:
 
         :param application_name: Unique identifier requests coming from this handler.
         :param auth_token: Token for authenticating requests to the server.
-        :param auth_token_type: Type of authentication-token.
+        :param auth_secret: Secret token.
         :param server_address: Address of server where to send messages.
         :param scheme: The scheme to use as string ('http' or 'https')
         :param send_interval: Seconds between sending batches.
@@ -61,7 +61,7 @@ class Sender:
 
         self.application_name = application_name
         self.auth_token = auth_token
-        self.auth_token_type = auth_token_type
+        self.auth_secret = auth_secret
         self.server_address = server_address
         self.send_interval = send_interval
         self.send_threshold = send_threshold
@@ -165,7 +165,7 @@ class Sender:
             "Content-Type": "application/json",
             "X-Application-Name": self.application_name,
             "X-Token": self.auth_token,
-            "X-Token-Type": self.auth_token_type,
+            "X-Secret": self.auth_secret,
         }
 
         # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -37,8 +37,8 @@ class Sender:
         auth_token: str,
         server_address: str,
         *,
-        auth_token_type: str = "gprofiler",
         scheme: str = "https",
+        auth_token_type: str = "",
         send_interval: float = 30.0,
         send_threshold: float = 0.8,
         send_min_interval: float = 10.0,
@@ -50,7 +50,7 @@ class Sender:
 
         :param application_name: Unique identifier requests coming from this handler.
         :param auth_token: Token for authenticating requests to the server.
-        :param auth_token_type: Type of authentication-token ('gprofiler' or 'aws').
+        :param auth_token_type: Type of authentication-token.
         :param server_address: Address of server where to send messages.
         :param scheme: The scheme to use as string ('http' or 'https')
         :param send_interval: Seconds between sending batches.

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -65,9 +65,9 @@ class Sender:
 
         self.application_name = application_name
         self.auth_token = auth_token
-        self.x_auth_type = x_auth_type,
-        self.x_auth_access_key_id = x_auth_access_key_id,
-        self.x_auth_secret_access_key = x_auth_secret_access_key,
+        self.x_auth_type = x_auth_type
+        self.x_auth_access_key_id = x_auth_access_key_id
+        self.x_auth_secret_access_key = x_auth_secret_access_key
         self.server_address = server_address
         self.send_interval = send_interval
         self.send_threshold = send_threshold
@@ -165,22 +165,16 @@ class Sender:
 
         return batch
 
-    def _prepare_headers(self) -> Dict[str, str]:
+    def _send_once_to_server(self, data: bytes) -> None:
         headers = {
             "Content-Encoding": "gzip",
             "Content-Type": "application/json",
             "X-Application-Name": self.application_name,
             "X-Token": self.auth_token,
+            "X-Auth-Type": self.x_auth_type,
+            "X-Auth-Access-Key-Id": self.x_auth_access_key_id,
+            "X-Auth-Secret-Access-Key": self.x_auth_secret_access_key,
         }
-
-        conditional_headers = [("X-Auth-Type", self.x_auth_type),
-                               ("X-Auth-Access-Key-Id", self.x_auth_access_key_id),
-                               ("X-Auth-Secret-Access-Key", self.x_auth_secret_access_key)]
-
-        return {**headers, **{k: v for k, v in conditional_headers if v and v != ('',)}}
-
-    def _send_once_to_server(self, data: bytes) -> None:
-        headers = self._prepare_headers()
 
         # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.
         data = gzip.compress(data, compresslevel=6)

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -37,6 +37,7 @@ class Sender:
         auth_token: str,
         server_address: str,
         *,
+        auth_token_type: str = "gprofiler",
         scheme: str = "https",
         send_interval: float = 30.0,
         send_threshold: float = 0.8,
@@ -49,6 +50,7 @@ class Sender:
 
         :param application_name: Unique identifier requests coming from this handler.
         :param auth_token: Token for authenticating requests to the server.
+        :param auth_token_type: Type of authentication-token ('gprofiler' or 'aws').
         :param server_address: Address of server where to send messages.
         :param scheme: The scheme to use as string ('http' or 'https')
         :param send_interval: Seconds between sending batches.
@@ -59,6 +61,7 @@ class Sender:
 
         self.application_name = application_name
         self.auth_token = auth_token
+        self.auth_token_type = auth_token_type
         self.server_address = server_address
         self.send_interval = send_interval
         self.send_threshold = send_threshold
@@ -162,6 +165,7 @@ class Sender:
             "Content-Type": "application/json",
             "X-Application-Name": self.application_name,
             "X-Token": self.auth_token,
+            "X-Token-Type": self.auth_token_type,
         }
 
         # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -124,7 +124,7 @@ class Sender:
 
         time_since_last_send = time.monotonic() - self.last_send_time
         return self.messages_buffer.count > 0 and (
-                (self.messages_buffer.utilized >= self.send_threshold) or (time_since_last_send >= self.send_interval)
+            (self.messages_buffer.utilized >= self.send_threshold) or (time_since_last_send >= self.send_interval)
         )
 
     def send(self) -> None:

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -72,6 +72,7 @@ class Sender:
         self.send_interval = send_interval
         self.send_threshold = send_threshold
         self.send_min_interval = send_min_interval
+
         self.max_send_tries = max_send_tries
         self.stdout_logger = get_stdout_logger()
         self.server_uri = f"{scheme}://{server_address}/api/v1/logs"
@@ -81,129 +82,118 @@ class Sender:
         self.messages_buffer: Optional[MessagesBuffer] = None
         self.metadata_callback: Callable[[], Dict] = lambda: {}
 
+    def start(self, messages_buffer: MessagesBuffer, metadata_callback: Callable[[], Dict]) -> None:
+        assert self.messages_buffer is None, "Call start once"
+        self.messages_buffer = messages_buffer
+        self.metadata_callback = metadata_callback
 
-def start(self, messages_buffer: MessagesBuffer, metadata_callback: Callable[[], Dict]) -> None:
-    assert self.messages_buffer is None, "Call start once"
-    self.messages_buffer = messages_buffer
-    self.metadata_callback = metadata_callback
+        self.last_send_time = 0.0
+        self.stop_event = threading.Event()
+        self.sending_thread = threading.Thread(target=self._send_loop, daemon=True, name="gLogger Logs Sending Thread")
+        self.sending_thread.start()
 
-    self.last_send_time = 0.0
-    self.stop_event = threading.Event()
-    self.sending_thread = threading.Thread(target=self._send_loop, daemon=True, name="gLogger Logs Sending Thread")
-    self.sending_thread.start()
+    def stop(self, timeout: float = 10) -> bool:
+        """
+        Signals to stop flushing messages asynchronously.
+        Blocks until current flushing operation has finished or `stop_timeout` seconds passed.
+        :return: Whether thread terminated within allotted timeout.
+        """
+        if self.stop_event.is_set():
+            return True
+        else:
+            self.stop_event.set()
+            self.sending_thread.join(timeout)
+            return not self.sending_thread.is_alive()
 
+    def _send_loop(self) -> None:
+        assert self.messages_buffer is not None
 
-def stop(self, timeout: float = 10) -> bool:
-    """
-    Signals to stop flushing messages asynchronously.
-    Blocks until current flushing operation has finished or `stop_timeout` seconds passed.
-    :return: Whether thread terminated within allotted timeout.
-    """
-    if self.stop_event.is_set():
-        return True
-    else:
-        self.stop_event.set()
-        self.sending_thread.join(timeout)
-        return not self.sending_thread.is_alive()
+        self.last_send_time = time.monotonic()
+        while not self.stop_event.is_set():
+            if self._should_send():
+                self.send()
+            self.stop_event.wait(self.send_min_interval)
 
-
-def _send_loop(self) -> None:
-    assert self.messages_buffer is not None
-
-    self.last_send_time = time.monotonic()
-    while not self.stop_event.is_set():
-        if self._should_send():
+        # send all remaining messages before terminating:
+        # Not thread-safe but we're fine with it as read only
+        if self.messages_buffer.count > 0:
             self.send()
-        self.stop_event.wait(self.send_min_interval)
 
-    # send all remaining messages before terminating:
-    # Not thread-safe but we're fine with it as read only
-    if self.messages_buffer.count > 0:
-        self.send()
+    def _should_send(self) -> bool:
+        assert self.messages_buffer is not None
 
-
-def _should_send(self) -> bool:
-    assert self.messages_buffer is not None
-
-    time_since_last_send = time.monotonic() - self.last_send_time
-    return self.messages_buffer.count > 0 and (
+        time_since_last_send = time.monotonic() - self.last_send_time
+        return self.messages_buffer.count > 0 and (
             (self.messages_buffer.utilized >= self.send_threshold) or (time_since_last_send >= self.send_interval)
-    )
-
-
-def send(self) -> None:
-    self.last_send_time = time.monotonic()
-    try:
-        batch = self._send_once()
-        self._drop_sent_batch(batch)
-    except Exception:
-        self.stdout_logger.exception(SERVER_SEND_ERROR_MESSAGE)
-
-
-def _drop_sent_batch(self, batch: SendBatch) -> None:
-    assert self.messages_buffer is not None
-    with self.messages_buffer.lock:
-        # The previous lost count has been accounted by the server:
-        self.messages_buffer.dropped -= batch.lost_logs_count
-
-        # Number of messages dropped while we were busy flushing:
-        dropped_inadvertently = self.messages_buffer.head_serial_no - batch.head_serial_no
-        remaining = len(batch.logs) - dropped_inadvertently
-        if remaining > 0:
-            # Drop the remainder:
-            self.messages_buffer.drop(remaining)
-
-        # Account for all the messages in the batch that were considered dropped:
-        self.messages_buffer.dropped -= len(batch.logs)
-
-
-def _send_once(self):
-    batch = self._make_batch()
-    protocol_data = {
-        "batch_id": batch.ident,
-        "metadata": self.metadata_callback(),
-        "lost_logs_count": batch.lost_logs_count,
-        "logs": "<LOGS_JSON>",
-    }
-    # batch.logs is a list of json strings so ','.join() it into the final json string instead of json-ing the list.
-    data = self.jsonify(protocol_data).replace('"<LOGS_JSON>"', f'[{",".join(batch.logs)}]').encode("utf-8")
-    self._send_once_to_server(data)
-
-    return batch
-
-
-def _send_once_to_server(self, data: bytes) -> None:
-    headers = {
-        "Content-Encoding": "gzip",
-        "Content-Type": "application/json",
-        "X-Application-Name": self.application_name,
-        "X-Token": self.auth_token,
-        "X-Auth-Type": self.x_auth_type,
-        "X-Auth-Access-Key-Id": self.x_auth_access_key_id,
-        "X-Auth-Secret-Access-Key": self.x_auth_secret_access_key,
-    }
-
-    # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.
-    data = gzip.compress(data, compresslevel=6)
-
-    response = self.session.post(
-        self.server_uri,
-        data=data,
-        headers=headers,
-        timeout=self.request_timeout,
-    )
-    response.raise_for_status()
-
-
-def _make_batch(self) -> SendBatch:
-    assert self.messages_buffer is not None
-    with self.messages_buffer.lock:
-        return SendBatch(
-            uuid.uuid4().hex,
-            self.messages_buffer.buffer[:],
-            self.messages_buffer.total_length,
-            self.messages_buffer.head_serial_no,
-            # The current dropped counter indicates lost messages. Any messages dropped from now on will also be
-            # considered dropped until proven to have been flushed successfully.
-            self.messages_buffer.dropped,
         )
+
+    def send(self) -> None:
+        self.last_send_time = time.monotonic()
+        try:
+            batch = self._send_once()
+            self._drop_sent_batch(batch)
+        except Exception:
+            self.stdout_logger.exception(SERVER_SEND_ERROR_MESSAGE)
+
+    def _drop_sent_batch(self, batch: SendBatch) -> None:
+        assert self.messages_buffer is not None
+        with self.messages_buffer.lock:
+            # The previous lost count has been accounted by the server:
+            self.messages_buffer.dropped -= batch.lost_logs_count
+
+            # Number of messages dropped while we were busy flushing:
+            dropped_inadvertently = self.messages_buffer.head_serial_no - batch.head_serial_no
+            remaining = len(batch.logs) - dropped_inadvertently
+            if remaining > 0:
+                # Drop the remainder:
+                self.messages_buffer.drop(remaining)
+
+            # Account for all the messages in the batch that were considered dropped:
+            self.messages_buffer.dropped -= len(batch.logs)
+
+    def _send_once(self):
+        batch = self._make_batch()
+        protocol_data = {
+            "batch_id": batch.ident,
+            "metadata": self.metadata_callback(),
+            "lost_logs_count": batch.lost_logs_count,
+            "logs": "<LOGS_JSON>",
+        }
+        # batch.logs is a list of json strings so ','.join() it into the final json string instead of json-ing the list.
+        data = self.jsonify(protocol_data).replace('"<LOGS_JSON>"', f'[{",".join(batch.logs)}]').encode("utf-8")
+        self._send_once_to_server(data)
+
+        return batch
+
+    def _send_once_to_server(self, data: bytes) -> None:
+        headers = {
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json",
+            "X-Application-Name": self.application_name,
+            "X-Token": self.auth_token,
+            "X-Secret": self.auth_secret,
+        }
+
+        # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.
+        data = gzip.compress(data, compresslevel=6)
+
+        response = self.session.post(
+            self.server_uri,
+            data=data,
+            headers=headers,
+            timeout=self.request_timeout,
+        )
+        response.raise_for_status()
+
+    def _make_batch(self) -> SendBatch:
+        assert self.messages_buffer is not None
+        with self.messages_buffer.lock:
+            return SendBatch(
+                uuid.uuid4().hex,
+                self.messages_buffer.buffer[:],
+                self.messages_buffer.total_length,
+                self.messages_buffer.head_serial_no,
+                # The current dropped counter indicates lost messages. Any messages dropped from now on will also be
+                # considered dropped until proven to have been flushed successfully.
+                self.messages_buffer.dropped,
+            )

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -32,25 +32,29 @@ class Sender:
     request_timeout: Union[float, Tuple[float, float]] = (1.5, 10)
 
     def __init__(
-        self,
-        application_name: str,
-        auth_token: str,
-        server_address: str,
-        *,
-        scheme: str = "https",
-        auth_secret: str = "",
-        send_interval: float = 30.0,
-        send_threshold: float = 0.8,
-        send_min_interval: float = 10.0,
-        max_send_tries: int = 3,
-        verify: bool = True,
+            self,
+            application_name: str,
+            auth_token: str,
+            server_address: str,
+            *,
+            scheme: str = "https",
+            x_auth_type: str = None,
+            x_auth_access_key_id: str = None,
+            x_auth_secret_access_key: str = None,
+            send_interval: float = 30.0,
+            send_threshold: float = 0.8,
+            send_min_interval: float = 10.0,
+            max_send_tries: int = 3,
+            verify: bool = True,
     ):
         """
         Create a new Sender and start flushing log messages in a background thread.
 
         :param application_name: Unique identifier requests coming from this handler.
         :param auth_token: Token for authenticating requests to the server.
-        :param auth_secret: Secret token.
+        :param x_auth_type: The type of authentication to use.
+        :param x_auth_access_key_id: The access key id to use for authentication.
+        :param x_auth_secret_access_key: The secret access key to use for authentication.
         :param server_address: Address of server where to send messages.
         :param scheme: The scheme to use as string ('http' or 'https')
         :param send_interval: Seconds between sending batches.
@@ -61,13 +65,14 @@ class Sender:
 
         self.application_name = application_name
         self.auth_token = auth_token
-        self.auth_secret = auth_secret
+        self.x_auth_type = x_auth_type,
+        self.x_auth_access_key_id = x_auth_access_key_id,
+        self.x_auth_secret_access_key = x_auth_secret_access_key,
         self.server_address = server_address
         self.send_interval = send_interval
         self.send_threshold = send_threshold
         self.send_min_interval = send_min_interval
         self.max_send_tries = max_send_tries
-
         self.stdout_logger = get_stdout_logger()
         self.server_uri = f"{scheme}://{server_address}/api/v1/logs"
         self.jsonify = JSONEncoder(separators=(",", ":"), default=repr).encode  # compact, no whitespace
@@ -76,118 +81,129 @@ class Sender:
         self.messages_buffer: Optional[MessagesBuffer] = None
         self.metadata_callback: Callable[[], Dict] = lambda: {}
 
-    def start(self, messages_buffer: MessagesBuffer, metadata_callback: Callable[[], Dict]) -> None:
-        assert self.messages_buffer is None, "Call start once"
-        self.messages_buffer = messages_buffer
-        self.metadata_callback = metadata_callback
 
-        self.last_send_time = 0.0
-        self.stop_event = threading.Event()
-        self.sending_thread = threading.Thread(target=self._send_loop, daemon=True, name="gLogger Logs Sending Thread")
-        self.sending_thread.start()
+def start(self, messages_buffer: MessagesBuffer, metadata_callback: Callable[[], Dict]) -> None:
+    assert self.messages_buffer is None, "Call start once"
+    self.messages_buffer = messages_buffer
+    self.metadata_callback = metadata_callback
 
-    def stop(self, timeout: float = 10) -> bool:
-        """
-        Signals to stop flushing messages asynchronously.
-        Blocks until current flushing operation has finished or `stop_timeout` seconds passed.
-        :return: Whether thread terminated within allotted timeout.
-        """
-        if self.stop_event.is_set():
-            return True
-        else:
-            self.stop_event.set()
-            self.sending_thread.join(timeout)
-            return not self.sending_thread.is_alive()
+    self.last_send_time = 0.0
+    self.stop_event = threading.Event()
+    self.sending_thread = threading.Thread(target=self._send_loop, daemon=True, name="gLogger Logs Sending Thread")
+    self.sending_thread.start()
 
-    def _send_loop(self) -> None:
-        assert self.messages_buffer is not None
 
-        self.last_send_time = time.monotonic()
-        while not self.stop_event.is_set():
-            if self._should_send():
-                self.send()
-            self.stop_event.wait(self.send_min_interval)
+def stop(self, timeout: float = 10) -> bool:
+    """
+    Signals to stop flushing messages asynchronously.
+    Blocks until current flushing operation has finished or `stop_timeout` seconds passed.
+    :return: Whether thread terminated within allotted timeout.
+    """
+    if self.stop_event.is_set():
+        return True
+    else:
+        self.stop_event.set()
+        self.sending_thread.join(timeout)
+        return not self.sending_thread.is_alive()
 
-        # send all remaining messages before terminating:
-        # Not thread-safe but we're fine with it as read only
-        if self.messages_buffer.count > 0:
+
+def _send_loop(self) -> None:
+    assert self.messages_buffer is not None
+
+    self.last_send_time = time.monotonic()
+    while not self.stop_event.is_set():
+        if self._should_send():
             self.send()
+        self.stop_event.wait(self.send_min_interval)
 
-    def _should_send(self) -> bool:
-        assert self.messages_buffer is not None
+    # send all remaining messages before terminating:
+    # Not thread-safe but we're fine with it as read only
+    if self.messages_buffer.count > 0:
+        self.send()
 
-        time_since_last_send = time.monotonic() - self.last_send_time
-        return self.messages_buffer.count > 0 and (
+
+def _should_send(self) -> bool:
+    assert self.messages_buffer is not None
+
+    time_since_last_send = time.monotonic() - self.last_send_time
+    return self.messages_buffer.count > 0 and (
             (self.messages_buffer.utilized >= self.send_threshold) or (time_since_last_send >= self.send_interval)
+    )
+
+
+def send(self) -> None:
+    self.last_send_time = time.monotonic()
+    try:
+        batch = self._send_once()
+        self._drop_sent_batch(batch)
+    except Exception:
+        self.stdout_logger.exception(SERVER_SEND_ERROR_MESSAGE)
+
+
+def _drop_sent_batch(self, batch: SendBatch) -> None:
+    assert self.messages_buffer is not None
+    with self.messages_buffer.lock:
+        # The previous lost count has been accounted by the server:
+        self.messages_buffer.dropped -= batch.lost_logs_count
+
+        # Number of messages dropped while we were busy flushing:
+        dropped_inadvertently = self.messages_buffer.head_serial_no - batch.head_serial_no
+        remaining = len(batch.logs) - dropped_inadvertently
+        if remaining > 0:
+            # Drop the remainder:
+            self.messages_buffer.drop(remaining)
+
+        # Account for all the messages in the batch that were considered dropped:
+        self.messages_buffer.dropped -= len(batch.logs)
+
+
+def _send_once(self):
+    batch = self._make_batch()
+    protocol_data = {
+        "batch_id": batch.ident,
+        "metadata": self.metadata_callback(),
+        "lost_logs_count": batch.lost_logs_count,
+        "logs": "<LOGS_JSON>",
+    }
+    # batch.logs is a list of json strings so ','.join() it into the final json string instead of json-ing the list.
+    data = self.jsonify(protocol_data).replace('"<LOGS_JSON>"', f'[{",".join(batch.logs)}]').encode("utf-8")
+    self._send_once_to_server(data)
+
+    return batch
+
+
+def _send_once_to_server(self, data: bytes) -> None:
+    headers = {
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json",
+        "X-Application-Name": self.application_name,
+        "X-Token": self.auth_token,
+        "X-Auth-Type": self.x_auth_type,
+        "X-Auth-Access-Key-Id": self.x_auth_access_key_id,
+        "X-Auth-Secret-Access-Key": self.x_auth_secret_access_key,
+    }
+
+    # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.
+    data = gzip.compress(data, compresslevel=6)
+
+    response = self.session.post(
+        self.server_uri,
+        data=data,
+        headers=headers,
+        timeout=self.request_timeout,
+    )
+    response.raise_for_status()
+
+
+def _make_batch(self) -> SendBatch:
+    assert self.messages_buffer is not None
+    with self.messages_buffer.lock:
+        return SendBatch(
+            uuid.uuid4().hex,
+            self.messages_buffer.buffer[:],
+            self.messages_buffer.total_length,
+            self.messages_buffer.head_serial_no,
+            # The current dropped counter indicates lost messages. Any messages dropped from now on will also be
+            # considered dropped until proven to have been flushed successfully.
+            self.messages_buffer.dropped,
         )
-
-    def send(self) -> None:
-        self.last_send_time = time.monotonic()
-        try:
-            batch = self._send_once()
-            self._drop_sent_batch(batch)
-        except Exception:
-            self.stdout_logger.exception(SERVER_SEND_ERROR_MESSAGE)
-
-    def _drop_sent_batch(self, batch: SendBatch) -> None:
-        assert self.messages_buffer is not None
-        with self.messages_buffer.lock:
-            # The previous lost count has been accounted by the server:
-            self.messages_buffer.dropped -= batch.lost_logs_count
-
-            # Number of messages dropped while we were busy flushing:
-            dropped_inadvertently = self.messages_buffer.head_serial_no - batch.head_serial_no
-            remaining = len(batch.logs) - dropped_inadvertently
-            if remaining > 0:
-                # Drop the remainder:
-                self.messages_buffer.drop(remaining)
-
-            # Account for all the messages in the batch that were considered dropped:
-            self.messages_buffer.dropped -= len(batch.logs)
-
-    def _send_once(self):
-        batch = self._make_batch()
-        protocol_data = {
-            "batch_id": batch.ident,
-            "metadata": self.metadata_callback(),
-            "lost_logs_count": batch.lost_logs_count,
-            "logs": "<LOGS_JSON>",
-        }
-        # batch.logs is a list of json strings so ','.join() it into the final json string instead of json-ing the list.
-        data = self.jsonify(protocol_data).replace('"<LOGS_JSON>"', f'[{",".join(batch.logs)}]').encode("utf-8")
-        self._send_once_to_server(data)
-
-        return batch
-
-    def _send_once_to_server(self, data: bytes) -> None:
-        headers = {
-            "Content-Encoding": "gzip",
-            "Content-Type": "application/json",
-            "X-Application-Name": self.application_name,
-            "X-Token": self.auth_token,
-            "X-Secret": self.auth_secret,
-        }
-
-        # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.
-        data = gzip.compress(data, compresslevel=6)
-
-        response = self.session.post(
-            self.server_uri,
-            data=data,
-            headers=headers,
-            timeout=self.request_timeout,
-        )
-        response.raise_for_status()
-
-    def _make_batch(self) -> SendBatch:
-        assert self.messages_buffer is not None
-        with self.messages_buffer.lock:
-            return SendBatch(
-                uuid.uuid4().hex,
-                self.messages_buffer.buffer[:],
-                self.messages_buffer.total_length,
-                self.messages_buffer.head_serial_no,
-                # The current dropped counter indicates lost messages. Any messages dropped from now on will also be
-                # considered dropped until proven to have been flushed successfully.
-                self.messages_buffer.dropped,
-            )

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -32,20 +32,20 @@ class Sender:
     request_timeout: Union[float, Tuple[float, float]] = (1.5, 10)
 
     def __init__(
-            self,
-            application_name: str,
-            auth_token: str,
-            server_address: str,
-            *,
-            scheme: str = "https",
-            x_auth_type: str = None,
-            x_auth_access_key_id: str = None,
-            x_auth_secret_access_key: str = None,
-            send_interval: float = 30.0,
-            send_threshold: float = 0.8,
-            send_min_interval: float = 10.0,
-            max_send_tries: int = 3,
-            verify: bool = True,
+        self,
+        application_name: str,
+        auth_token: str,
+        server_address: str,
+        *,
+        scheme: str = "https",
+        x_auth_type: str = None,
+        x_auth_access_key_id: str = None,
+        x_auth_secret_access_key: str = None,
+        send_interval: float = 30.0,
+        send_threshold: float = 0.8,
+        send_min_interval: float = 10.0,
+        max_send_tries: int = 3,
+        verify: bool = True,
     ):
         """
         Create a new Sender and start flushing log messages in a background thread.
@@ -124,7 +124,7 @@ class Sender:
 
         time_since_last_send = time.monotonic() - self.last_send_time
         return self.messages_buffer.count > 0 and (
-            (self.messages_buffer.utilized >= self.send_threshold) or (time_since_last_send >= self.send_interval)
+                (self.messages_buffer.utilized >= self.send_threshold) or (time_since_last_send >= self.send_interval)
         )
 
     def send(self) -> None:

--- a/glogger/sender.py
+++ b/glogger/sender.py
@@ -171,7 +171,9 @@ class Sender:
             "Content-Type": "application/json",
             "X-Application-Name": self.application_name,
             "X-Token": self.auth_token,
-            "X-Secret": self.auth_secret,
+            "X-Auth-Type": self.x_auth_type,
+            "X-Auth-Access-Key-Id": self.x_auth_access_key_id,
+            "X-Auth-Secret-Access-Key": self.x_auth_secret_access_key,
         }
 
         # Default compression level (9) is slowest. Level 6 trades a bit of compression for speed.


### PR DESCRIPTION
this PR adds authentication parameters to the Sender requests to allow G-Logger Backend to authenticate the request using aws token **or** g-profiler token. 

new params:
-  x_auth_type: The type of authentication to use. ('aws')
-  x_auth_access_key_id: The access key id to use for authentication.
-  x_auth_secret_access_key: The secret access key to use for authentication.