### PR TITLE
Add method to check if exe is stripped

### DIFF
--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -183,3 +183,10 @@ def get_libc_type(elf: ELFType) -> LibcType:
             return LibcType.STATIC_LIBC
 
         return LibcType.STATIC_NO_LIBC
+
+
+def elf_has_debug_info(elf: ELFType) -> bool:
+    with open_elf(elf) as elf:
+        if elf.has_dwarf_info():
+            return elf.get_dwarf_info().has_debug_info
+    return False

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -185,7 +185,7 @@ def get_libc_type(elf: ELFType) -> LibcType:
         return LibcType.STATIC_NO_LIBC
 
 
-def elf_is_stripped(elf: ELFType) -> None:
+def elf_is_stripped(elf: ELFType) -> bool:
     with open_elf(elf) as elf:
         if elf.get_section_by_name(".symtab") is not None:
             return False

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -185,8 +185,8 @@ def get_libc_type(elf: ELFType) -> LibcType:
         return LibcType.STATIC_NO_LIBC
 
 
-def elf_has_debug_info(elf: ELFType) -> bool:
+def elf_is_stripped(elf: ELFType) -> None:
     with open_elf(elf) as elf:
-        if elf.has_dwarf_info():
-            return elf.get_dwarf_info().has_debug_info
-    return False
+        if elf.get_section_by_name(".symtab") is not None:
+            return False
+        return True

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -187,6 +187,4 @@ def get_libc_type(elf: ELFType) -> LibcType:
 
 def elf_is_stripped(elf: ELFType) -> bool:
     with open_elf(elf) as elf:
-        if elf.get_section_by_name(".symtab") is not None:
-            return False
-        return True
+        return elf.get_section_by_name(".symtab") is None


### PR DESCRIPTION
Connected with: https://github.com/Granulate/gprofiler/issues/804.

As far as I understand if executable has debug information it is not-stripped, and if it hasn't then it is stripped. According to pyelftools this information is stored in has_debug_info property in DWARFInfo object which can be obtained by using get_dwarf_info() method on elf file.