### PR TITLE
Add cluster_id to Spark/YARN collector

### DIFF
--- a/granulate_utils/metrics/sampler.py
+++ b/granulate_utils/metrics/sampler.py
@@ -273,7 +273,9 @@ class BigDataSampler(Sampler):
 
         if self._applications_metrics:
             self._collectors.append(
-                SparkApplicationMetricsCollector(self._cluster_mode, self._master_address, self._logger, yarn_collector=yarn_collector)
+                SparkApplicationMetricsCollector(
+                    self._cluster_mode, self._master_address, self._logger, yarn_collector=yarn_collector
+                )
             )
 
     def discover(self) -> bool:

--- a/granulate_utils/metrics/sampler.py
+++ b/granulate_utils/metrics/sampler.py
@@ -262,8 +262,10 @@ class BigDataSampler(Sampler):
         """
         This function fills in self._spark_samplers with the appropriate collectors.
         """
+        yarn_collector = None
         if self._cluster_mode == SPARK_YARN_MODE:
-            self._collectors.append(YarnCollector(self._master_address, self._logger))
+            yarn_collector = YarnCollector(self._master_address, self._logger)
+            self._collectors.append(yarn_collector)
 
         # In Standalone and Mesos we'd use applications metrics
         if self._cluster_mode in (SPARK_STANDALONE_MODE, SPARK_MESOS_MODE):
@@ -271,7 +273,7 @@ class BigDataSampler(Sampler):
 
         if self._applications_metrics:
             self._collectors.append(
-                SparkApplicationMetricsCollector(self._cluster_mode, self._master_address, self._logger)
+                SparkApplicationMetricsCollector(self._cluster_mode, self._master_address, self._logger, yarn_collector=yarn_collector)
             )
 
     def discover(self) -> bool:

--- a/granulate_utils/metrics/spark.py
+++ b/granulate_utils/metrics/spark.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Iterable, Optional, Tuple
 from bs4 import BeautifulSoup
 from requests import HTTPError
 
-from granulate_utils.metrics.yarn import YarnCollector
 from granulate_utils.metrics import (
     Collector,
     Sample,
@@ -28,6 +27,7 @@ from granulate_utils.metrics.metrics import (
     SPARK_RUNNING_APPS_COUNT_METRIC,
 )
 from granulate_utils.metrics.mode import SPARK_MESOS_MODE, SPARK_STANDALONE_MODE, SPARK_YARN_MODE
+from granulate_utils.metrics.yarn import YarnCollector
 
 SPARK_APPS_PATH = "api/v1/applications"
 MESOS_MASTER_APP_PATH = "/frameworks"
@@ -170,7 +170,13 @@ class SparkRunningApps:
 
 
 class SparkApplicationMetricsCollector(Collector):
-    def __init__(self, cluster_mode: str, master_address: str, logger: logging.LoggerAdapter, yarn_collector: Optional[YarnCollector] = None) -> None:
+    def __init__(
+        self,
+        cluster_mode: str,
+        master_address: str,
+        logger: logging.LoggerAdapter,
+        yarn_collector: Optional[YarnCollector] = None,
+    ) -> None:
         self.master_address = master_address
         self._cluster_mode = cluster_mode
         self.logger = logger
@@ -295,4 +301,6 @@ class SparkApplicationMetricsCollector(Collector):
                 self.logger.exception("Could not gather spark executors metrics")
 
     def _running_applications_count_metric(self, running_apps: Dict[str, Tuple[str, str]]) -> Iterable[Sample]:
-        yield Sample(name=SPARK_RUNNING_APPS_COUNT_METRIC, value=len(running_apps), labels={"cluster_id": self._cluster_id})
+        yield Sample(
+            name=SPARK_RUNNING_APPS_COUNT_METRIC, value=len(running_apps), labels={"cluster_id": self._cluster_id}
+        )

--- a/granulate_utils/metrics/yarn.py
+++ b/granulate_utils/metrics/yarn.py
@@ -5,8 +5,8 @@
 # (C) Datadog, Inc. 2018-present. All rights reserved.
 # Licensed under a 3-clause BSD style license (see LICENSE.bsd3).
 #
-import logging
 import functools
+import logging
 from typing import Dict, Iterable, List, Optional
 
 from granulate_utils.metrics import Collector, Sample, json_request, samples_from_json
@@ -24,7 +24,7 @@ class ResourceManagerAPI:
 
     def info(self, **kwargs) -> Optional[Dict]:
         return json_request(self._info_url, **kwargs).get("clusterInfo")
-    
+
     def apps(self, **kwargs) -> List[Dict]:
         return json_request(self._apps_url, **kwargs).get("apps", {}).get("app", [])
 
@@ -43,7 +43,6 @@ class YarnCollector(Collector):
         self.rm = ResourceManagerAPI(self.rm_address)
         self.logger = logger
 
-
     def collect(self) -> Iterable[Sample]:
         try:
             yield from self._cluster_metrics()
@@ -51,15 +50,14 @@ class YarnCollector(Collector):
         except Exception:
             self.logger.exception("Could not gather yarn metrics")
 
-    @property
-    @functools.lru_cache(maxsize=8192)
+    @functools.cached_property
     def cluster_id(self) -> str:
         try:
-            return self.rm.info()["id"]
+            cluster_info = self.rm.info()
+            return cluster_info.get("id", "err") if cluster_info else "err"
         except Exception:
             self.logger.exception("Could not gather yarn cluster id")
             return "err"
-    
 
     def _cluster_metrics(self) -> Iterable[Sample]:
         try:


### PR DESCRIPTION
1. Add `cluster_id` label to identify different clusters in the spark/yarn collector. 
2. We're using the Hadoop Yarn cluster identifier to uniquely identify a cluster. This means that mostly Yarn is supported, preliminary support for other cluster types is implemented (using the master host name)