### PR TITLE
Add identification of golang binaries

### DIFF
--- a/granulate_utils/golang.py
+++ b/granulate_utils/golang.py
@@ -25,8 +25,7 @@ def get_golang_buildid(process: Process) -> Optional[str]:
     elf_path = f"/proc/{process.pid}/exe"
     try:
         # section .note.go.buildid has been added since version 1.5: https://github.com/golang/go/issues/11048
-        golang_buildid = get_elf_buildid(elf_path, ".note.go.buildid", lambda note: note.n_name == "Go")
-        return golang_buildid
+        return get_elf_buildid(elf_path, ".note.go.buildid", lambda note: note.n_name == "Go")
     except FileNotFoundError:
         raise NoSuchProcess(process.pid)
 

--- a/granulate_utils/golang.py
+++ b/granulate_utils/golang.py
@@ -9,12 +9,26 @@ from typing import Optional
 
 from psutil import NoSuchProcess, Process
 
-from granulate_utils.linux.elf import read_elf_symbol, read_elf_va
+from granulate_utils.linux.elf import get_elf_buildid, read_elf_symbol, read_elf_va
 from granulate_utils.linux.process import is_kernel_thread
 
 
 def is_golang_process(process: Process) -> bool:
-    return not is_kernel_thread(process) and get_process_golang_version(process) is not None
+    return not is_kernel_thread(process) and get_golang_buildid(process) is not None
+
+
+@functools.lru_cache(maxsize=4096)
+def get_golang_buildid(process: Process) -> Optional[str]:
+    """
+    Gets the golang build ID embedded in an ELF file section as a string, or None if not present.
+    """
+    elf_path = f"/proc/{process.pid}/exe"
+    try:
+        # section .note.go.buildid has been added since version 1.5: https://github.com/golang/go/issues/11048
+        golang_buildid = get_elf_buildid(elf_path, ".note.go.buildid", lambda note: note.n_name == "Go")
+        return golang_buildid
+    except FileNotFoundError:
+        raise NoSuchProcess(process.pid)
 
 
 @functools.lru_cache(maxsize=4096)

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from enum import Enum, auto
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, List, Optional, TypeVar, Union, cast
+from typing import Callable, List, Optional, TypeVar, Union, cast
 
 import psutil
 from elftools.elf.elffile import ELFError, ELFFile  # type: ignore
@@ -71,7 +71,7 @@ def get_elf_arch(elf: ELFType) -> str:
         return elf.get_machine_arch()
 
 
-def get_elf_buildid(elf: ELFType, section: str, note_check: Callable[[Any], Any] = lambda n: True) -> Optional[str]:
+def get_elf_buildid(elf: ELFType, section: str, note_check: Callable[[NoteSection], bool]) -> Optional[str]:
     """
     Gets the build ID embedded in an ELF file note section as a hex string,
     or None if not present.

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -73,16 +73,16 @@ def get_elf_arch(elf: ELFType) -> str:
 
 def get_elf_buildid(elf: ELFType, section: str, note_check: Callable[[NoteSection], bool]) -> Optional[str]:
     """
-    Gets the build ID embedded in an ELF file note section as a hex string,
+    Gets the build ID embedded in an ELF file note section as a string,
     or None if not present.
     Lambda argument is used to verify that note meets caller's requirements.
     """
     with open_elf(elf) as elf:
-        build_id_section = elf.get_section_by_name(section)
-        if build_id_section is None or not isinstance(build_id_section, NoteSection):
+        note_section = elf.get_section_by_name(section)
+        if note_section is None or not isinstance(note_section, NoteSection):
             return None
 
-        for note in build_id_section.iter_notes():
+        for note in note_section.iter_notes():
             if note_check(note):
                 return cast(str, note.n_desc)
         else:

--- a/granulate_utils/linux/elf.py
+++ b/granulate_utils/linux/elf.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from enum import Enum, auto
 from functools import wraps
 from pathlib import Path
-from typing import Callable, List, Optional, TypeVar, Union, cast
+from typing import Any, Callable, List, Optional, TypeVar, Union, cast
 
 import psutil
 from elftools.elf.elffile import ELFError, ELFFile  # type: ignore
@@ -71,18 +71,19 @@ def get_elf_arch(elf: ELFType) -> str:
         return elf.get_machine_arch()
 
 
-def get_elf_buildid(elf: ELFType) -> Optional[str]:
+def get_elf_buildid(elf: ELFType, section: str, note_check: Callable[[Any], Any] = lambda n: True) -> Optional[str]:
     """
-    Gets the build ID embedded in an ELF file section as a hex string,
+    Gets the build ID embedded in an ELF file note section as a hex string,
     or None if not present.
+    Lambda argument is used to verify that note meets caller's requirements.
     """
     with open_elf(elf) as elf:
-        build_id_section = elf.get_section_by_name(".note.gnu.build-id")
+        build_id_section = elf.get_section_by_name(section)
         if build_id_section is None or not isinstance(build_id_section, NoteSection):
             return None
 
         for note in build_id_section.iter_notes():
-            if note.n_type == "NT_GNU_BUILD_ID":
+            if note_check(note):
                 return cast(str, note.n_desc)
         else:
             return None
@@ -96,7 +97,7 @@ def get_elf_id(elf: ELFType) -> str:
     we instead grab its SHA1.
     """
     with open_elf(elf) as elf:
-        buildid = get_elf_buildid(elf)
+        buildid = get_elf_buildid(elf, ".note.gnu.build-id", lambda note: note.n_type == "NT_GNU_BUILD_ID")
         if buildid is not None:
             return f"buildid:{buildid}"
 


### PR DESCRIPTION
Support identification of Golang binaries by looking for ELF section `.note.go.buildid`, supported since Go 1.5.
Reference: https://github.com/golang/go/issues/11048.