### PR TITLE
Java: fix `parse_jvm_version` `vm_name` regex pattern

### DIFF
--- a/granulate_utils/java.py
+++ b/granulate_utils/java.py
@@ -191,18 +191,18 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
         build = int(matched[0])
 
     # There is no real format here, just use the entire description string until the part which describes the build.
-    m = re.match(r"(.*?) \((?:product )?build", lines[2])
+    m = re.match(r"(.*?) (?:\(.*\))?\((?:product )?build", lines[2])
     assert m is not None, f"Missing build description? {lines[2]}"
     vm_name = m.group(1)
 
-    if vm_name.startswith("OpenJDK"):
+    if vm_name.startswith("OpenJDK") or vm_name.startswith("Java HotSpot"):
         vm_type: VmType = "HotSpot"
     elif vm_name.startswith("Zing"):
         vm_type = "Zing"
     elif vm_name == "Eclipse OpenJ9 VM":
         vm_type = "OpenJ9"
     else:
-        # TODO: additional types?
+        # There may be additional types that have not yet been categorized.
         vm_type = None
 
     if vm_type == "Zing":

--- a/granulate_utils/java.py
+++ b/granulate_utils/java.py
@@ -191,18 +191,18 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
         build = int(matched[0])
 
     # There is no real format here, just use the entire description string until the part which describes the build.
-    m = re.match(r"(.*?) \((?:product )?.*build", lines[2])
+    m = re.match(r"(.*?) \((?:product )?build", lines[2])
     assert m is not None, f"Missing build description? {lines[2]}"
     vm_name = m.group(1)
 
-    if vm_name.startswith("OpenJDK") or vm_name.startswith("Java HotSpot"):
+    if vm_name.startswith("OpenJDK"):
         vm_type: VmType = "HotSpot"
     elif vm_name.startswith("Zing"):
         vm_type = "Zing"
     elif vm_name == "Eclipse OpenJ9 VM":
         vm_type = "OpenJ9"
     else:
-        # There may be additional types that have not yet been categorized.
+        # TODO: additional types?
         vm_type = None
 
     if vm_type == "Zing":

--- a/granulate_utils/java.py
+++ b/granulate_utils/java.py
@@ -191,18 +191,18 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
         build = int(matched[0])
 
     # There is no real format here, just use the entire description string until the part which describes the build.
-    m = re.match(r"(.*?) \((?:product )?build", lines[2])
+    m = re.match(r"(.*?) \((?:product )?.*build", lines[2])
     assert m is not None, f"Missing build description? {lines[2]}"
     vm_name = m.group(1)
 
-    if vm_name.startswith("OpenJDK"):
+    if vm_name.startswith("OpenJDK") or vm_name.startswith("Java HotSpot"):
         vm_type: VmType = "HotSpot"
     elif vm_name.startswith("Zing"):
         vm_type = "Zing"
     elif vm_name == "Eclipse OpenJ9 VM":
         vm_type = "OpenJ9"
     else:
-        # TODO: additional types?
+        # There may be additional types that have not yet been categorized.
         vm_type = None
 
     if vm_type == "Zing":

--- a/tests/granulate_utils/test_jvm_version.py
+++ b/tests/granulate_utils/test_jvm_version.py
@@ -9,6 +9,20 @@ from granulate_utils.java import JvmVersion, parse_jvm_version
 @pytest.mark.parametrize(
     "java_version,jvm_version_or_err",
     [
+        (
+            """java version "18.0.0.1" 2022-05-19
+Java(TM) SE Runtime Environment (build 18.0.0.1+2-9)
+Java HotSpot(TM) 64-Bit Server VM (build 18.0.0.1+2-9, mixed mode, sharing)
+""",
+            JvmVersion(Version("18.0.0.1"), 2, "Java HotSpot(TM) 64-Bit Server VM", "HotSpot", None),
+        ),
+        (
+            """openjdk version "1.8.0_125"
+OpenJDK Runtime Environment (Temurin)(build 1.8.0_125-b09)
+OpenJDK 64-Bit Server VM (Temurin)(build 25.125-b09, mixed mode)
+""",
+            JvmVersion(Version("8.125"), 9, "OpenJDK 64-Bit Server VM", "HotSpot", None),
+        ),
         # 8
         (
             """openjdk version "1.8.0_352"

--- a/tests/granulate_utils/test_jvm_version.py
+++ b/tests/granulate_utils/test_jvm_version.py
@@ -10,6 +10,13 @@ from granulate_utils.java import JvmVersion, parse_jvm_version
     "java_version,jvm_version_or_err",
     [
         (
+            """openjdk version "1.8.0_265"
+OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_265-b01)
+OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.265-b01, mixed mode)
+""",
+            JvmVersion(Version("8.265"), 1, "OpenJDK 64-Bit Server VM", "HotSpot", None),
+        ),
+        (
             """java version "18.0.0.1" 2022-05-19
 Java(TM) SE Runtime Environment (build 18.0.0.1+2-9)
 Java HotSpot(TM) 64-Bit Server VM (build 18.0.0.1+2-9, mixed mode, sharing)


### PR DESCRIPTION
1. better regex:
e.g. this regex was failed to match the [functions' own `java -version` output example](https://github.com/Granulate/granulate-utils/blob/dadafab/granulate_utils/java.py#L136)
2. on my PC it's `Java HotSpot(TM) 64-Bit Server VM`... so I added support
3. replaced `TODO` with an informative comment
4. tests, including the documented `java -version` example from `parse_jvm_version()`

one question I have is why do we need the regex? why can't we just `lines[2].startswith()` or even `if 'HotSpot' in lines[2]`?
