### PR TITLE
Support Mappings in the Metadata type

### DIFF
--- a/granulate_utils/metadata/__init__.py
+++ b/granulate_utils/metadata/__init__.py
@@ -3,6 +3,6 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
-from typing import Dict, Union
+from typing import Mapping, Union
 
-Metadata = Dict[str, Union[str, int, bool, Dict]]
+Metadata = Mapping[str, Union[str, int, bool, Mapping]]


### PR DESCRIPTION
Support Mappings in Metadata so we could pass other dict-like objects.