### PR TITLE
fix: json_request can return null

### DIFF
--- a/granulate_utils/metrics/__init__.py
+++ b/granulate_utils/metrics/__init__.py
@@ -44,12 +44,13 @@ def rest_request(url: str, **kwargs: Any) -> requests.Response:
     return response
 
 
-def json_request(url: str, **kwargs) -> Any:
+def json_request(url: str, default: Any, **kwargs) -> Any:
     """
     Query the given URL using HTTP GET and return the JSON response.
     :param kwargs: request parameters
     """
-    return rest_request(url, **kwargs).json()
+    value = rest_request(url, **kwargs).json()
+    return default if value is None else value
 
 
 def get_request_url(address, url: str) -> str:
@@ -85,7 +86,7 @@ def rest_request_to_json(url: str, object_path: str, *args: Any, **kwargs: Any) 
     Query url/object_path/args/... and return the JSON response
     """
     url = bake_url(url, object_path, *args)
-    return json_request(url, **kwargs)
+    return json_request(url, None, **kwargs)
 
 
 def rest_request_raw(url: str, object_path: str, *args: Any, **kwargs: Any) -> requests.Response:

--- a/granulate_utils/metrics/yarn.py
+++ b/granulate_utils/metrics/yarn.py
@@ -22,16 +22,16 @@ class ResourceManagerAPI:
         self._scheduler_url = f"{rm_address}/ws/v1/cluster/scheduler"
 
     def apps(self, **kwargs) -> List[Dict]:
-        return json_request(self._apps_url, **kwargs).get("apps", {}).get("app", [])
+        return json_request(self._apps_url, {}, **kwargs).get("apps", {}).get("app", [])
 
     def metrics(self, **kwargs) -> Optional[Dict]:
-        return json_request(self._metrics_url, **kwargs).get("clusterMetrics")
+        return json_request(self._metrics_url, {}, **kwargs).get("clusterMetrics")
 
     def nodes(self, **kwargs) -> List[Dict]:
-        return json_request(self._nodes_url, **kwargs).get("nodes", {}).get("node", [])
+        return json_request(self._nodes_url, {}, **kwargs).get("nodes", {}).get("node", [])
 
     def scheduler(self, **kwargs) -> Optional[Dict]:
-        return json_request(self._scheduler_url, **kwargs).get("scheduler", {}).get("schedulerInfo")
+        return json_request(self._scheduler_url, {}, **kwargs).get("scheduler", {}).get("schedulerInfo")
 
 
 class YarnCollector(Collector):


### PR DESCRIPTION
### Problem

`json_request` is used like it always returns value but does not handle `null` and other responses

### Solution

Improve `json_request` to return default dict when response is `null`

