### PR TITLE
fix: hadoop v2.6.0 compatibility

### DIFF
--- a/granulate_utils/metrics/yarn.py
+++ b/granulate_utils/metrics/yarn.py
@@ -92,6 +92,9 @@ class YarnCollector(Collector):
         Also, we don't want to collect DECOMMISSIONED because in EMR nodes are
         considered DECOMMISSIONED forever and are never removed from the nodes list
         """
-        return (
-            "NEW,RUNNING,UNHEALTHY,DECOMMISSIONING" if self.rm.is_version_at_least("2.8.0") else "NEW,RUNNING,UNHEALTHY"
-        )
+
+        # DECOMMISSIONING was added in 2.8.0
+        if self.rm.is_version_at_least("2.8.0"):
+            return "NEW,RUNNING,UNHEALTHY,DECOMMISSIONING"
+        else:
+            return "NEW,RUNNING,UNHEALTHY"

--- a/granulate_utils/metrics/yarn.py
+++ b/granulate_utils/metrics/yarn.py
@@ -22,16 +22,19 @@ class ResourceManagerAPI:
         self._scheduler_url = f"{rm_address}/ws/v1/cluster/scheduler"
 
     def apps(self, **kwargs) -> List[Dict]:
-        return json_request(self._apps_url, {}, **kwargs).get("apps", {}).get("app", [])
+        apps = json_request(self._apps_url, {}, **kwargs).get("apps") or {}
+        return apps.get("app", [])
 
     def metrics(self, **kwargs) -> Optional[Dict]:
         return json_request(self._metrics_url, {}, **kwargs).get("clusterMetrics")
 
     def nodes(self, **kwargs) -> List[Dict]:
-        return json_request(self._nodes_url, {}, **kwargs).get("nodes", {}).get("node", [])
+        nodes = json_request(self._nodes_url, {}, **kwargs).get("nodes") or {}
+        return nodes.get("node", [])
 
     def scheduler(self, **kwargs) -> Optional[Dict]:
-        return json_request(self._scheduler_url, {}, **kwargs).get("scheduler", {}).get("schedulerInfo")
+        scheduler = json_request(self._scheduler_url, {}, **kwargs).get("scheduler") or {}
+        return scheduler.get("schedulerInfo")
 
 
 class YarnCollector(Collector):


### PR DESCRIPTION
HADOOP v2 and v3 behaves differently. In hadoop v2 nested JSON objects can contain nulls.

e.g. `curl http://localhost:8088/ws/v1/cluster/apps?finalStatus=KILLED`
v3 response: `{"apps":{}}`
v2 response: `{"apps":null}`


