### PR TITLE
git based version

### DIFF
--- a/granulate_utils/__init__.py
+++ b/granulate_utils/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("granulate-utils")

--- a/granulate_utils/__init__.py
+++ b/granulate_utils/__init__.py
@@ -2,4 +2,10 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-__version__ = "0.0.1"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("granulate-utils")
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "0.0.1"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-import re
 from pathlib import Path
 from typing import List
 
@@ -14,15 +13,11 @@ def read_requirements(path: str) -> List[str]:
         return [line for line in f.readlines() if not line.startswith("#")]
 
 
-version = re.search(r'__version__\s*=\s*"(.*?)"', Path("granulate_utils/__init__.py").read_text())
-assert version is not None, "could not parse version!"
-
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="granulate_utils",
-    version=version.group(1),
     author="Granulate",
     author_email="",  # TODO
     description="Granulate Python utilities",
@@ -37,4 +32,8 @@ setuptools.setup(
     include_package_data=True,
     install_requires=read_requirements("requirements.txt"),
     python_requires=">=3.8",
+    setup_requires=["setuptools-git-versioning<2"],
+    setuptools_git_versioning={
+        "enabled": True,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-from pathlib import Path
 from typing import List
 
 import setuptools


### PR DESCRIPTION
This PR automates versioning using `git-describe`.
Versions are in the form of `0.0.2.post<N>+git.<hash>`
The `.post<N>` part is [PEP 440 (versioning) compliant](https://peps.python.org/pep-0440/#post-releases) so `pip` knows how to order these. It is incremented with every commit.
No changes required in the various `requirements.txt`s