### PR TITLE
Glogger extra exception

### DIFF
--- a/glogger/extra_adapter.py
+++ b/glogger/extra_adapter.py
@@ -1,3 +1,7 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
 import logging
 from typing import Any, Dict, Mapping, MutableMapping, Tuple
 

--- a/glogger/extra_adapter.py
+++ b/glogger/extra_adapter.py
@@ -6,8 +6,6 @@ import logging
 import sys
 from typing import Any, Dict, Mapping, MutableMapping, Tuple
 
-from .extra_exception import ExtraException
-
 
 class ExtraAdapter(logging.LoggerAdapter):
     """
@@ -53,9 +51,9 @@ class ExtraAdapter(logging.LoggerAdapter):
             exc_info = sys.exc_info()
             # If exc_info is True, then there must be an exception:
             assert exc_info is not None
-            if isinstance(exc_info[1], ExtraException):
-                # Merge extra attributes from exception into extra, the exception's extra attributes take precedence:
-                extra = {**extra, **exc_info[1].extra}
+            if (exc_extra := getattr(exc_info[1], "extra", None)) is not None and isinstance(exc_extra, dict):
+                # Merge 'extra' attributes from exception into extra, the exception's extra attributes take precedence:
+                extra = {**extra, **exc_extra}
 
         # Retain all extras as attributes on the record, and add "extra" attribute that contains all the extras:
         logging_kwargs.update({"extra": {**extra, "extra": extra}})

--- a/glogger/extra_adapter.py
+++ b/glogger/extra_adapter.py
@@ -45,12 +45,8 @@ class ExtraAdapter(logging.LoggerAdapter):
 
         extra = self.get_extra(**logging_kwargs)
 
-        if logging_kwargs.get("exc_info") is True:
-            # If exc_info is True, and the exception is subclassing ExtraException, then add the extra attributes
-            # from the exception to the extra attributes of the record:
-            exc_info = sys.exc_info()
-            # If exc_info is True, then there must be an exception:
-            assert exc_info is not None
+        if logging_kwargs.get("exc_info") is True and (exc_info := sys.exc_info()) is not None:
+            # If exc_info is True, and the exception has a dict in the 'extra' attribute, merge it into extra:
             if (exc_extra := getattr(exc_info[1], "extra", None)) is not None and isinstance(exc_extra, dict):
                 # Merge 'extra' attributes from exception into extra, the exception's extra attributes take precedence:
                 extra = {**extra, **exc_extra}

--- a/glogger/extra_exception.py
+++ b/glogger/extra_exception.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+
+from typing import Any
+
+
+class ExtraException(Exception):
+    """
+    Derive from this exception to be able to pass **extra kwargs to the logger.
+    """
+
+    def __init__(self, *args: Any, **extra: Any) -> None:
+        super().__init__(*args)
+        self.extra = extra

--- a/tests/glogger/test_extra_adapter.py
+++ b/tests/glogger/test_extra_adapter.py
@@ -2,6 +2,12 @@ import logging
 from typing import Any, Mapping
 
 from glogger.extra_adapter import ExtraAdapter
+from glogger.extra_exception import ExtraException
+
+
+class CustomException(ExtraException):
+    def __init__(self, **extra: Any) -> None:
+        super().__init__("My Exception", **extra)
 
 
 class CustomGetExtraAdapter(ExtraAdapter):
@@ -38,3 +44,17 @@ def test_custom_get_extra(caplog):
     assert record.neo == "keanu reeves"
     assert hasattr(record, "extra")
     assert record.extra == dict(test=6, neo="keanu reeves")
+
+
+def test_extra_exception(caplog):
+    caplog.set_level(logging.INFO)
+    try:
+        raise CustomException(test=6)
+    except Exception as e:
+        assert e.extra == {"test": 6}
+        ExtraAdapter(logging.getLogger()).exception("test message")
+    record = caplog.records[0]
+    assert record.message == "test message"
+    assert record.test == 6
+    assert hasattr(record, "extra")
+    assert record.extra == dict(test=6)

--- a/tests/glogger/test_extra_adapter.py
+++ b/tests/glogger/test_extra_adapter.py
@@ -1,13 +1,16 @@
 import logging
 from typing import Any, Mapping
 
+import pytest
+
 from glogger.extra_adapter import ExtraAdapter
 from glogger.extra_exception import ExtraException
 
 
-class CustomException(ExtraException):
-    def __init__(self, **extra: Any) -> None:
-        super().__init__("My Exception", **extra)
+class CustomException(Exception):
+    def __init__(self) -> None:
+        super().__init__("My Exception")
+        self.extra = {"test": 6}
 
 
 class CustomGetExtraAdapter(ExtraAdapter):
@@ -18,43 +21,45 @@ class CustomGetExtraAdapter(ExtraAdapter):
         return extra
 
 
-def test_other_kwargs_in_extra(caplog):
+def test_other_kwargs_in_extra(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
     ExtraAdapter(logging.getLogger()).info("test message", test=6)
     record = caplog.records[0]
-    assert record.test == 6
+    assert getattr(record, "test") == 6
     assert hasattr(record, "extra")
-    assert record.extra == dict(test=6)
+    assert getattr(record, "extra") == dict(test=6)
 
 
-def test_logging_kwargs_not_present_in_extra(caplog):
+def test_logging_kwargs_not_present_in_extra(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
     ExtraAdapter(logging.getLogger()).info("test message", stacklevel=8, stack_info=True, test=6)
     record = caplog.records[0]
-    assert record.test == 6
+    assert getattr(record, "test") == 6
     assert hasattr(record, "extra")
-    assert record.extra == dict(test=6)
+    assert getattr(record, "extra") == dict(test=6)
 
 
-def test_custom_get_extra(caplog):
+def test_custom_get_extra(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
     CustomGetExtraAdapter(logging.getLogger()).info("test message", test=6)
     record = caplog.records[0]
-    assert record.test == 6
-    assert record.neo == "keanu reeves"
+    assert getattr(record, "test") == 6
+    assert getattr(record, "neo") == "keanu reeves"
     assert hasattr(record, "extra")
-    assert record.extra == dict(test=6, neo="keanu reeves")
+    assert getattr(record, "extra") == dict(test=6, neo="keanu reeves")
 
 
-def test_extra_exception(caplog):
+@pytest.mark.parametrize(
+    "exc", [CustomException(), ExtraException("My Exception", test=6)], ids=["CustomException", "ExtraException"]
+)
+def test_extra_from_exception(caplog: pytest.LogCaptureFixture, exc: Exception) -> None:
     caplog.set_level(logging.INFO)
     try:
-        raise CustomException(test=6)
-    except Exception as e:
-        assert e.extra == {"test": 6}
+        raise exc
+    except Exception:
         ExtraAdapter(logging.getLogger()).exception("test message")
     record = caplog.records[0]
     assert record.message == "test message"
-    assert record.test == 6
+    assert getattr(record, "test") == 6
     assert hasattr(record, "extra")
-    assert record.extra == dict(test=6)
+    assert getattr(record, "extra") == dict(test=6)


### PR DESCRIPTION
This PR adds the ability for `ExtraAdapter` to collect `extra` attrs from Exception objects, for use when doing:
`adapater.exception("An exception has occured")`

For convenience, also added an `ExtraException` base-class 