### PR TITLE
containers: use Process objects instead of pids

### DIFF
--- a/granulate_utils/containers/container.py
+++ b/granulate_utils/containers/container.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
 
+import psutil
+
 
 @dataclass
 class TimeInfo:
@@ -28,7 +30,7 @@ class Container:
     labels: Dict[str, str]
     running: bool
     # None if not requested / container is dead
-    pid: Optional[int]
+    process: Optional[psutil.Process]
     # None if not requested, make sure to pass all_info=True
     time_info: Optional[TimeInfo]
 

--- a/granulate_utils/containers/cri.py
+++ b/granulate_utils/containers/cri.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import List, Optional, Union
 
 import grpc  # type: ignore # no types-grpc sadly
+import psutil
 
 from granulate_utils.containers.container import Container, ContainersClientInterface, TimeInfo
 from granulate_utils.exceptions import ContainerNotFound, CriNotAvailableError
@@ -136,6 +137,6 @@ class CriClient(ContainersClientInterface):
             id=container.id,
             labels=container.labels,
             running=container.state == CONTAINER_RUNNING,
-            pid=pid,
+            process=psutil.Process(pid) if pid is not None else None,
             time_info=time_info,
         )

--- a/granulate_utils/containers/docker.py
+++ b/granulate_utils/containers/docker.py
@@ -10,6 +10,7 @@ import docker
 import docker.errors
 import docker.models.containers
 from dateutil.parser import isoparse
+import psutil
 
 from granulate_utils.containers.container import Container, ContainersClientInterface, TimeInfo
 from granulate_utils.exceptions import ContainerNotFound
@@ -58,6 +59,6 @@ class DockerClient(ContainersClientInterface):
             id=container.id,
             labels=container.labels,
             running=container.status == "running",
-            pid=pid,
+            process=psutil.Process(pid) if pid is not None else None,
             time_info=time_info,
         )

--- a/granulate_utils/containers/docker.py
+++ b/granulate_utils/containers/docker.py
@@ -9,8 +9,8 @@ from typing import List, Optional
 import docker
 import docker.errors
 import docker.models.containers
-from dateutil.parser import isoparse
 import psutil
+from dateutil.parser import isoparse
 
 from granulate_utils.containers.container import Container, ContainersClientInterface, TimeInfo
 from granulate_utils.exceptions import ContainerNotFound


### PR DESCRIPTION
To guard against pid reuse after container exits.