### PR TITLE
Suppress PermissionError in get_host_pid due to restricted processes

### DIFF
--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -334,7 +334,7 @@ def get_host_pid(nspid: int, container_id: str) -> Optional[int]:
         try:
             if os.readlink(f"/proc/{process.pid}/ns/pid") == pid_namespace and get_process_nspid(process) == nspid:
                 return process.pid
-        except (FileNotFoundError, NoSuchProcess):
+        except (FileNotFoundError, NoSuchProcess, PermissionError):
             continue
 
     return None


### PR DESCRIPTION
In some environments such as Databricks and Fargate, some processes may be restricted and return EACCESS on `readlink('/proc/<pid>/ns/pid')`, we don't want these processes to fail `get_host_pid`.