### PR TITLE
YARN: expose filter_properties utility

### DIFF
--- a/granulate_utils/metrics/yarn/__init__.py
+++ b/granulate_utils/metrics/yarn/__init__.py
@@ -1,5 +1,12 @@
 from granulate_utils.metrics.yarn.metrics_collector import YarnCollector
 from granulate_utils.metrics.yarn.resource_manager import YARN_RM_CLASSNAME, ResourceManagerAPI
-from granulate_utils.metrics.yarn.utils import YarnNodeInfo, get_yarn_node_info
+from granulate_utils.metrics.yarn.utils import YarnNodeInfo, filter_properties, get_yarn_node_info
 
-__all__ = ["YARN_RM_CLASSNAME", "ResourceManagerAPI", "YarnCollector", "YarnNodeInfo", "get_yarn_node_info"]
+__all__ = [
+    "YARN_RM_CLASSNAME",
+    "ResourceManagerAPI",
+    "YarnCollector",
+    "YarnNodeInfo",
+    "get_yarn_node_info",
+    "filter_properties",
+]

--- a/granulate_utils/metrics/yarn/utils.py
+++ b/granulate_utils/metrics/yarn/utils.py
@@ -242,9 +242,9 @@ def get_yarn_properties(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Return only YARN properties
     """
-    resource_names = ("yarn-site.xml", "programmatically")
+    resource_names = ("yarn-site.xml", "programmatically", "Dataproc Cluster Properties")
     return {
-        "properties": _get_properties(
+        "properties": filter_properties(
             config,
             lambda x: x["resource"] in resource_names and x["key"].startswith("yarn."),
         )
@@ -255,10 +255,10 @@ def get_all_properties(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Return all properties
     """
-    return {"properties": _get_properties(config, lambda x: True)}
+    return {"properties": filter_properties(config, lambda x: True)}
 
 
-def _get_properties(
+def filter_properties(
     config: Dict[str, Any],
     predicate: Callable[[Dict[str, Any]], bool],
 ) -> List[Dict[str, Any]]:

--- a/tests/granulate_utils/metrics/test_yarn_config_properties.py
+++ b/tests/granulate_utils/metrics/test_yarn_config_properties.py
@@ -1,0 +1,73 @@
+import re
+from typing import Any, Dict
+
+import pytest
+
+from granulate_utils.metrics.yarn.utils import filter_properties, get_yarn_properties
+
+
+@pytest.fixture
+def yarn_config() -> Dict[str, Any]:
+    return {
+        "properties": [
+            {
+                "key": "yarn.nodemanager.resource.memory-mb",
+                "value": "125872",
+                "isFinal": False,
+                "resource": "Dataproc Cluster Properties",
+            },
+            {
+                "key": "yarn.resourcemanager.address",
+                "value": "host-32-m.internal:8032",
+                "isFinal": False,
+                "resource": "programmatically",
+            },
+            {
+                "key": "yarn.federation.state-store.sql.password",
+                "value": "password1",
+                "isFinal": False,
+                "resource": "yarn-site.xml",
+            },
+            {
+                "key": "mapreduce.map.memory.mb",
+                "value": "2048",
+                "isFinal": False,
+                "resource": "mapred-site.xml",
+            },
+        ]
+    }
+
+
+def test_should_get_only_yarn_config_properties(yarn_config: dict) -> None:
+    assert get_yarn_properties(yarn_config)["properties"] == [
+        {
+            "key": "yarn.nodemanager.resource.memory-mb",
+            "value": "125872",
+            "resource": "Dataproc Cluster Properties",
+        },
+        {
+            "key": "yarn.resourcemanager.address",
+            "value": "host-32-m.internal:8032",
+            "resource": "programmatically",
+        },
+        {
+            "key": "yarn.federation.state-store.sql.password",
+            "value": "*****",
+            "resource": "yarn-site.xml",
+        },
+    ]
+
+
+def test_should_filter_and_mask_yarn_config_properties(yarn_config: dict) -> None:
+    assert filter_properties(yarn_config, lambda prop: bool(re.search(r"(Dataproc|yarn-site)", prop["resource"]))) == [
+        {
+            "key": "yarn.nodemanager.resource.memory-mb",
+            "value": "125872",
+            "resource": "Dataproc Cluster Properties",
+        },
+        {
+            "key": "yarn.federation.state-store.sql.password",
+            "value": "*****",
+            "resource": "yarn-site.xml",
+        },
+    ]


### PR DESCRIPTION
Whitelist `Dataproc Cluster Properties` when collecting yarn config properties