### PR TITLE
granulate-utils: Fix resolve_proc_root_links

### DIFF
--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -54,8 +54,9 @@ def resolve_host_root_links(ns_path: str) -> str:
 
 
 def abs_path_name_parts(path: str) -> Collection[str]:
-    assert os.path.isabs(path), f"Expected {path!r} to be absolute"
-    return Path(path).parts[1:]  # skip the / (or multiple /// as .parts gives them)
+    parts = Path(path).parts
+    assert parts[0].startswith("/"), f"Expected {path!r} to be absolute"
+    return parts[1:]
 
 
 def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -7,9 +7,10 @@ import ctypes
 import enum
 import os
 import re
+from collections import deque
 from pathlib import Path
 from threading import Thread
-from typing import Callable, List, Optional, TypeVar, Union
+from typing import Callable, Collection, List, Optional, TypeVar, Union
 
 from psutil import NoSuchProcess, Process, process_iter
 
@@ -52,6 +53,11 @@ def resolve_host_root_links(ns_path: str) -> str:
     return resolve_proc_root_links(HOST_ROOT_PREFIX, ns_path)
 
 
+def abs_path_name_parts(path: str) -> Collection[str]:
+    assert os.path.isabs(path), f"Expected {path!r} to be absolute"
+    return Path(path).parts[1:]  # skip the / (or multiple /// as .parts gives them)
+
+
 def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
     """
     Resolves "ns_path" which (possibly) resides in another mount namespace.
@@ -62,25 +68,32 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
     To work around that, we resolve the path component by component; if any component "escapes", we
     add the /proc/pid/root prefix once again.
     """
-    assert ns_path[0] == "/", f"expected {ns_path!r} to be absolute"
-    parts = Path(ns_path).parts
-
+    parts = deque(abs_path_name_parts(ns_path))
     path = proc_root
     seen = set()
-    for part in parts[1:]:  # skip the / (or multiple /// as .parts gives them)
-        next_path = os.path.join(path, part)
-        while os.path.islink(next_path):
-            if next_path in seen:
-                raise RuntimeError("Symlink loop from %r" % os.path.join(path, part))
-            seen.add(next_path)
-            link = os.readlink(next_path)
-            if os.path.isabs(link):
-                # absolute - prefix with proc_root
-                next_path = proc_root + link
-            else:
-                # relative: just join
-                next_path = os.path.join(os.path.dirname(next_path), link)
-        path = next_path
+
+    while parts:
+        part = parts.popleft()
+        path = os.path.join(path, part)
+
+        if not os.path.islink(path):
+            continue
+
+        # detect symlink loops
+        if path in seen:
+            raise RuntimeError("Symlink loop from %r" % os.path.join(path, part))
+        seen.add(path)
+
+        # resolve the part
+        ns_link = os.readlink(path)
+        if os.path.isabs(ns_link):
+            # absolute - reset to root and encode the resolved absolute link in parts
+            path = proc_root
+            parts = deque(abs_path_name_parts(ns_link)) + parts
+        else:
+            # relative - use the parent dir as we resolved the last part and encode the new resolved ones
+            path = os.path.dirname(path)
+            parts = deque(Path(ns_link).parts) + parts
 
     return path
 

--- a/tests/granulate_utils/test_ns_utils.py
+++ b/tests/granulate_utils/test_ns_utils.py
@@ -7,7 +7,7 @@ from pytest import TempdirFactory
 from granulate_utils.linux.ns import resolve_proc_root_links
 
 
-# Here for comparison purposes
+# Here for comparison purposes (taken from revision: cb6b26477e8c95bc09e653dd74b5f5c18ecd537b)
 def resolve_proc_root_links_old(proc_root: str, ns_path: str) -> str:
     """
     Resolves "ns_path" which (possibly) resides in another mount namespace.

--- a/tests/granulate_utils/test_ns_utils.py
+++ b/tests/granulate_utils/test_ns_utils.py
@@ -1,0 +1,100 @@
+import os
+from pathlib import Path
+
+from pytest import TempdirFactory
+
+from granulate_utils.linux.ns import resolve_proc_root_links
+
+
+# Here for comparison purposes
+def resolve_proc_root_links_old(proc_root: str, ns_path: str) -> str:
+    """
+    Resolves "ns_path" which (possibly) resides in another mount namespace.
+
+    If ns_path contains absolute symlinks, it can't be accessed merely by /proc/pid/root/ns_path,
+    because the resolved absolute symlinks will "escape" the /proc/pid/root base.
+
+    To work around that, we resolve the path component by component; if any component "escapes", we
+    add the /proc/pid/root prefix once again.
+    """
+    assert ns_path[0] == "/", f"expected {ns_path!r} to be absolute"
+    parts = Path(ns_path).parts
+
+    path = proc_root
+    seen = set()
+    for part in parts[1:]:  # skip the / (or multiple /// as .parts gives them)
+        next_path = os.path.join(path, part)
+        while os.path.islink(next_path):
+            if next_path in seen:
+                raise RuntimeError("Symlink loop from %r" % os.path.join(path, part))
+            seen.add(next_path)
+            link = os.readlink(next_path)
+            if os.path.isabs(link):
+                # absolute - prefix with proc_root
+                next_path = proc_root + link
+            else:
+                # relative: just join
+                next_path = os.path.join(os.path.dirname(next_path), link)
+        path = next_path
+
+    return path
+
+
+def test_resolve_proc_root_links_compound_links(tmpdir_factory: TempdirFactory):
+    """
+    We construct the following case:
+    {tmpdir}/link
+        link -> {tmpdir}/a/c
+        a -> {tmpdir}/b
+    Eventually we expect {tmpdir}/link to resolve to {tmpdir}/b/c
+    """
+    tmpdir = Path(tmpdir_factory.mktemp("tmpdir"))
+
+    link = tmpdir.joinpath("link")
+    link.symlink_to(tmpdir / "a" / "c", target_is_directory=True)
+
+    a = tmpdir / "a"
+    a.symlink_to(tmpdir / "b", target_is_directory=True)
+
+    expected_resolved_path = tmpdir / "b" / "c"
+    expected_resolved_path.mkdir(parents=True)
+
+    # Make sure we got the directory structure correct
+    assert link.resolve() == expected_resolved_path
+
+    # Make sure resolve_proc_root_links got it correct as well
+    proc_root = "/proc/self/root"
+    assert resolve_proc_root_links(proc_root, str(link)) == str(expected_resolved_path)
+
+    # Make sure the old implementation got it wrong
+    assert resolve_proc_root_links_old(proc_root, str(link)) == proc_root + str(a / "c")
+
+
+def test_resolve_proc_root_links_relative_compound_links(tmpdir_factory: TempdirFactory):
+    """
+    We construct the following case:
+    {tmpdir}/link
+        link -> a/c
+        a -> b
+    Eventually we expect {tmpdir}/link to resolve to {tmpdir}/b/c
+    """
+    tmpdir = Path(tmpdir_factory.mktemp("tmpdir"))
+
+    link = tmpdir.joinpath("link")
+    link.symlink_to("a/c", target_is_directory=True)
+
+    a = tmpdir / "a"
+    a.symlink_to("b", target_is_directory=True)
+
+    expected_resolved_path = tmpdir / "b" / "c"
+    expected_resolved_path.mkdir(parents=True)
+
+    # Make sure we got the directory structure correct
+    assert link.resolve() == expected_resolved_path
+
+    # Make sure resolve_proc_root_links got it correct as well
+    proc_root = "/proc/self/root"
+    assert resolve_proc_root_links(proc_root, str(link)) == str(expected_resolved_path)
+
+    # Make sure the old implementation got it wrong
+    assert resolve_proc_root_links_old(proc_root, str(link)) == str(a / "c")

--- a/tests/granulate_utils/test_ns_utils.py
+++ b/tests/granulate_utils/test_ns_utils.py
@@ -64,7 +64,7 @@ def test_resolve_proc_root_links_compound_links(tmpdir_factory: TempdirFactory):
 
     # Make sure resolve_proc_root_links got it correct as well
     proc_root = "/proc/self/root"
-    assert resolve_proc_root_links(proc_root, str(link)) == str(expected_resolved_path)
+    assert resolve_proc_root_links(proc_root, str(link)) == proc_root + str(expected_resolved_path)
 
     # Make sure the old implementation got it wrong
     assert resolve_proc_root_links_old(proc_root, str(link)) == proc_root + str(a / "c")
@@ -94,7 +94,7 @@ def test_resolve_proc_root_links_relative_compound_links(tmpdir_factory: Tempdir
 
     # Make sure resolve_proc_root_links got it correct as well
     proc_root = "/proc/self/root"
-    assert resolve_proc_root_links(proc_root, str(link)) == str(expected_resolved_path)
+    assert resolve_proc_root_links(proc_root, str(link)) == proc_root + str(expected_resolved_path)
 
     # Make sure the old implementation got it wrong
-    assert resolve_proc_root_links_old(proc_root, str(link)) == str(a / "c")
+    assert resolve_proc_root_links_old(proc_root, str(link)) == proc_root + str(a / "c")

--- a/tests/granulate_utils/test_ns_utils.py
+++ b/tests/granulate_utils/test_ns_utils.py
@@ -1,7 +1,7 @@
 import os
-import pytest
-
 from pathlib import Path
+
+import pytest
 from pytest import TempdirFactory
 
 from granulate_utils.linux.ns import resolve_proc_root_links
@@ -41,7 +41,7 @@ def resolve_proc_root_links_old(proc_root: str, ns_path: str) -> str:
     return path
 
 
-@pytest.mark.parametrize('relative', [True, False])
+@pytest.mark.parametrize("relative", [True, False])
 def test_resolve_proc_root_links_compound_links(relative: bool, tmpdir_factory: TempdirFactory):
     """
     We construct the following case:


### PR DESCRIPTION
 Fix resolve_proc_root_links handling of links that resolve to sub-path links.

Example:
```
{tmpdir}/link
    link -> {tmpdir}/a/c
    a -> {tmpdir}/b
Eventually we expect {tmpdir}/link to resolve to {tmpdir}/b/c
```