### PR TITLE
Clear psutil's process exe cache

### DIFF
--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -29,7 +29,7 @@ def process_exe(process: psutil.Process) -> str:
 
     See https://github.com/giampaolo/psutil/pull/2062
     """
-    # Clear the "exe" cache on the process object. It can change after cache if it was cached during fork-exec.
+    # Clear the "exe" cache on the process object. It can change after being cached if the process execed.
     process._exe = None  # type: ignore
     exe = process.exe()
     if exe == "":

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -29,6 +29,8 @@ def process_exe(process: psutil.Process) -> str:
 
     See https://github.com/giampaolo/psutil/pull/2062
     """
+    # Clear the "exe" cache on the process object. It can change after cache if it was cached during fork-exec.
+    process._exe = None
     exe = process.exe()
     if exe == "":
         if is_process_zombie(process):

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -30,7 +30,7 @@ def process_exe(process: psutil.Process) -> str:
     See https://github.com/giampaolo/psutil/pull/2062
     """
     # Clear the "exe" cache on the process object. It can change after cache if it was cached during fork-exec.
-    process._exe = None # typing: ignore
+    process._exe = None  # typing: ignore
     exe = process.exe()
     if exe == "":
         if is_process_zombie(process):

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -30,7 +30,7 @@ def process_exe(process: psutil.Process) -> str:
     See https://github.com/giampaolo/psutil/pull/2062
     """
     # Clear the "exe" cache on the process object. It can change after cache if it was cached during fork-exec.
-    process._exe = None
+    process._exe = None # typing: ignore
     exe = process.exe()
     if exe == "":
         if is_process_zombie(process):

--- a/granulate_utils/linux/process.py
+++ b/granulate_utils/linux/process.py
@@ -30,7 +30,7 @@ def process_exe(process: psutil.Process) -> str:
     See https://github.com/giampaolo/psutil/pull/2062
     """
     # Clear the "exe" cache on the process object. It can change after cache if it was cached during fork-exec.
-    process._exe = None  # typing: ignore
+    process._exe = None  # type: ignore
     exe = process.exe()
     if exe == "":
         if is_process_zombie(process):


### PR DESCRIPTION
Fix a bug that resulted in psutil's cache. The fix is clearing the cache before using the exe.