### PR TITLE
Remove backoff-stubs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ types-setuptools==57.4.3
 types-psutil==5.8.0
 grpcio-tools==1.43.0
 types-dataclasses==0.6.6
-backoff-stubs~=1.10
 pytest~=7.0.1
 pytest-asyncio~=0.21.0
 types-python-dateutil~=2.8.2


### PR DESCRIPTION
backoff isn't required by this package, and this dev-requirement fails my CI for projects that have both `granulate-utils` and `backoff>2`