### PR TITLE
cgroup v1 take into account mount root

### DIFF
--- a/granulate_utils/linux/cgroups_v2/cgroup.py
+++ b/granulate_utils/linux/cgroups_v2/cgroup.py
@@ -281,7 +281,7 @@ def _get_controller_relative_path(
 def _get_unified_controller_relative_path(process: Optional[psutil.Process] = None) -> Optional[str]:
     for process_cgroup in get_process_cgroups(process):
         if process_cgroup.hier_id == "0":
-            return process_cgroup.relative_path.lstrip("/")
+            return process_cgroup.relative_path
 
     return None
 

--- a/granulate_utils/linux/cgroups_v2/cgroup.py
+++ b/granulate_utils/linux/cgroups_v2/cgroup.py
@@ -16,11 +16,13 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from pathlib import Path
 from typing import List, Literal, Mapping, Optional, Union
 
 import psutil
 from psutil import Process
+from typing_extensions import Self
 
 from granulate_utils.exceptions import CgroupControllerNotMounted
 from granulate_utils.linux import ns
@@ -77,7 +79,7 @@ def get_process_cgroups(process: Optional[psutil.Process] = None) -> List[ProcCg
     return [ProcCgroupLine(line) for line in text.splitlines()]
 
 
-def _find_v1_hierarchies() -> Mapping[str, str]:
+def _find_v1_hierarchies() -> Mapping[str, tuple[str, str]]:
     """
     Finds all the mounted hierarchies for all currently enabled cgroup v1 controllers.
     :return: A mapping from cgroup controller names to their respective hierarchies.
@@ -90,12 +92,13 @@ def _find_v1_hierarchies() -> Mapping[str, str]:
         if controllers:
             hierarchy = mount.mount_point
             hierarchy = ns.resolve_host_root_links(hierarchy)
+            mount_root = ns.resolve_host_root_links(mount.root)
             for controller in controllers:
-                hierarchies[controller] = hierarchy
+                hierarchies[controller] = (hierarchy, mount_root)
     return hierarchies
 
 
-def _find_v2_hierarchy() -> Optional[str]:
+def _find_v2_hierarchy() -> Optional[tuple[str, str]]:
     """
     Finds the mounted unified hierarchy for cgroup v2 controllers.
     """
@@ -108,7 +111,8 @@ def _find_v2_hierarchy() -> Optional[str]:
         raise Exception("More than one cgroup2 mount found!")
     path = cgroup2_mounts[0].mount_point
     path = ns.resolve_host_root_links(path)
-    return path
+    mount_root = ns.resolve_host_root_links(cgroup2_mounts[0].root)
+    return path, mount_root
 
 
 # Cgroup v1 and v2 handle the cgroup assigned processes using cgroup.procs
@@ -126,10 +130,12 @@ class CgroupCore:
 
     cgroup_abs_path: Path
     cgroup_mount_path: Path
+    cgroup_mount_root: Path
 
-    def __init__(self, cgroup_abs_path: Path, cgroup_mount_path: Path):
+    def __init__(self, cgroup_abs_path: Path, cgroup_mount_path: Path, cgroup_mount_root: Path):
         self.cgroup_abs_path = cgroup_abs_path
         self.cgroup_mount_path = cgroup_mount_path
+        self.cgroup_mount_root = cgroup_mount_root
 
     def get_pids_in_cgroup(self) -> set[int]:
         return {int(proc) for proc in self.read_from_interface_file(CGROUP_PROCS_FILE).split()}
@@ -171,8 +177,29 @@ class CgroupCore:
         return int(val)
 
     @classmethod
-    def build_object(cls, cgroup_abs_path: Path, mount_point: Path):
-        return cls(cgroup_abs_path, mount_point)
+    def build_object(cls, cgroup_abs_path: Path, mount_point: Path, cgroup_source_path: Path):
+        return cls(cgroup_abs_path, mount_point, cgroup_source_path)
+
+    def with_new_path(self, new_path: Path | str) -> Self:
+        new_path = Path(new_path)
+        # Absolute paths can either be under cgroup_mount_path (e.g. /sys/fs/cgroup/...)
+        # or relative to the cgroup_mount_root ('/' if not in a container, '/docker/<guid>' if docker on V1)
+        # if read from /proc/pid/cgroup
+        if new_path.is_absolute():
+            try:
+                # If new_path is relative to the mount path, use it as it is
+                new_path.relative_to(self.cgroup_mount_path)
+            except ValueError:
+                # If not relative to cgroup_mount_path, check if it's relative to mount_root
+
+                # we suppress ValueError to maintain compatability with the old code:
+                # absolute paths remain unchanged if not starting with cgroup_mount_root
+                with suppress(ValueError):
+                    new_path = new_path.relative_to(self.cgroup_mount_root)
+
+        if not new_path.is_absolute():
+            new_path = self.cgroup_abs_path / new_path
+        return type(self)(new_path, self.cgroup_mount_path, self.cgroup_mount_root)
 
 
 class CgroupCoreV1(CgroupCore):
@@ -219,10 +246,12 @@ def _get_cgroup_mount(controller: ControllerType) -> Optional[CgroupCore]:
     v2_path = _find_v2_hierarchy()
     if controller in v1_paths:
         # Either v1 or hybrid with the requested controller bound to a v1 hierarchy
-        return CgroupCoreV1(Path(v1_paths[controller]), Path(v1_paths[controller]))
+        mount_point, mount_root = v1_paths[controller]
+        return CgroupCoreV1(Path(mount_point), Path(mount_point), Path(mount_root))
     if v2_path:
+        mount_path, mount_root = v2_path
         # v2 (unified) - check given controller is supported in cgroup v2
-        cgroup_v2 = CgroupCoreV2(Path(v2_path), Path(v2_path))
+        cgroup_v2 = CgroupCoreV2(Path(mount_path), Path(mount_path), Path(mount_root))
         if cgroup_v2.is_controller_supported(controller):
             return cgroup_v2
     # No cgroup mount of the requested controller
@@ -238,17 +267,7 @@ def _get_cgroup_mount_checked(controller: ControllerType) -> CgroupCore:
 
 def _get_cgroup_from_path(controller: ControllerType, cgroup_path_or_full_path: Path) -> CgroupCore:
     cgroup_mount = _get_cgroup_mount_checked(controller)
-
-    try:
-        cgroup_path_or_full_path.relative_to(cgroup_mount.cgroup_abs_path)
-        # it's a full path
-        cgroup_abs_path = cgroup_path_or_full_path
-    except ValueError:
-        cgroup_path_or_full_path = Path(cgroup_path_or_full_path.as_posix().lstrip("/"))
-        # it's a path relative to controller mount point
-        cgroup_abs_path = cgroup_mount.cgroup_abs_path / cgroup_path_or_full_path
-
-    return cgroup_mount.build_object(cgroup_abs_path, cgroup_mount.cgroup_mount_path)
+    return cgroup_mount.with_new_path(cgroup_path_or_full_path)
 
 
 def _get_controller_relative_path(
@@ -256,7 +275,7 @@ def _get_controller_relative_path(
 ) -> Optional[str]:
     for process_cgroup in get_process_cgroups(process):
         if controller in process_cgroup.controllers:
-            return process_cgroup.relative_path.lstrip("/")
+            return process_cgroup.relative_path
 
     return None
 
@@ -278,15 +297,11 @@ def _get_cgroup_for_process(controller: ControllerType, process: Optional[psutil
     if cgroup_mount.is_v1:
         controller_cgroup_relative_path = _get_controller_relative_path(controller, process)
         if controller_cgroup_relative_path is not None:
-            return cgroup_mount.build_object(
-                cgroup_mount.cgroup_abs_path / controller_cgroup_relative_path, cgroup_mount.cgroup_mount_path
-            )
+            return cgroup_mount.with_new_path(controller_cgroup_relative_path)
     elif cgroup_mount.is_v2:
         unified_cgroup_relative_path = _get_unified_controller_relative_path(process)
         if unified_cgroup_relative_path is not None:
-            return cgroup_mount.build_object(
-                cgroup_mount.cgroup_abs_path / unified_cgroup_relative_path, cgroup_mount.cgroup_mount_path
-            )
+            return cgroup_mount.with_new_path(unified_cgroup_relative_path)
 
     raise Exception(f"{controller!r} not found")
 

--- a/tests/granulate_utils/test_cgroups.py
+++ b/tests/granulate_utils/test_cgroups.py
@@ -36,7 +36,8 @@ def test_get_cgroup_current_process():
     full_path = Path("/root_path/dummy")
 
     with patch(
-        "granulate_utils.linux.cgroups_v2.cgroup._get_cgroup_mount", return_value=CgroupCoreV1(root_path, Path("."))
+        "granulate_utils.linux.cgroups_v2.cgroup._get_cgroup_mount",
+        return_value=CgroupCoreV1(root_path, Path("."), Path("/")),
     ):
         with patch(
             "granulate_utils.linux.cgroups_v2.cgroup.read_proc_file",
@@ -46,7 +47,8 @@ def test_get_cgroup_current_process():
             assert cgroup.cgroup_abs_path == full_path
 
     with patch(
-        "granulate_utils.linux.cgroups_v2.cgroup._get_cgroup_mount", return_value=CgroupCoreV2(root_path, root_path)
+        "granulate_utils.linux.cgroups_v2.cgroup._get_cgroup_mount",
+        return_value=CgroupCoreV2(root_path, root_path, Path("/")),
     ):
         with patch(
             "granulate_utils.linux.cgroups_v2.cgroup.read_proc_file",
@@ -57,7 +59,8 @@ def test_get_cgroup_current_process():
 
     with pytest.raises(Exception) as exception:
         with patch(
-            "granulate_utils.linux.cgroups_v2.cgroup._get_cgroup_mount", return_value=CgroupCoreV2(root_path, root_path)
+            "granulate_utils.linux.cgroups_v2.cgroup._get_cgroup_mount",
+            return_value=CgroupCoreV2(root_path, root_path, Path("/")),
         ):
             with patch(
                 "granulate_utils.linux.cgroups_v2.cgroup.read_proc_file",
@@ -79,7 +82,7 @@ def test_cpu_controller_v1(tmp_path_factory: TempPathFactory):
     cpu_quota.write_text("50")
     cpu_stat.write_text("stat_value 1")
 
-    cgroup_v1 = CgroupCoreV1(cpu_controller_dir, tmp_dir)
+    cgroup_v1 = CgroupCoreV1(cpu_controller_dir, tmp_dir, Path("/"))
     cpu_controller = CpuControllerFactory.get_cpu_controller(cgroup_v1)
     assert cpu_controller.get_cpu_limit_cores() == 0.5
     stat_data = cpu_controller.get_stat()
@@ -104,7 +107,7 @@ def test_cpu_controller_v2(tmp_path_factory: TempPathFactory):
     cpu_max.write_text("50 100")
     cpu_stat.write_text("stat_value 1")
 
-    cgroup_v2 = CgroupCoreV2(cpu_controller_dir, cpu_controller_dir)
+    cgroup_v2 = CgroupCoreV2(cpu_controller_dir, cpu_controller_dir, Path("/"))
     cpu_controller = CpuControllerFactory.get_cpu_controller(cgroup_v2)
     assert cpu_controller.get_cpu_limit_cores() == 0.5
     stat_data = cpu_controller.get_stat()
@@ -135,7 +138,7 @@ def test_memory_controller_v1(tmp_path_factory: TempPathFactory):
     max_bytes_usage.write_text("400")
     usage_in_bytes.write_text("500")
 
-    cgroup_v1 = CgroupCoreV1(memory_controller_dir, tmp_dir)
+    cgroup_v1 = CgroupCoreV1(memory_controller_dir, tmp_dir, Path("/"))
     memory_controller = MemoryControllerFactory.get_memory_controller(cgroup_v1)
     assert memory_controller.get_memory_limit() == 128
     assert memory_controller.get_max_usage_in_bytes() == 400
@@ -164,7 +167,7 @@ def test_memory_controller_v2(tmp_path_factory: TempPathFactory):
     swap_bytes_limit.write_text("100")
     usage_in_bytes.write_text("500")
 
-    cgroup_v2 = CgroupCoreV2(memory_controller_dir, memory_controller_dir)
+    cgroup_v2 = CgroupCoreV2(memory_controller_dir, memory_controller_dir, Path("/"))
     memory_controller = MemoryControllerFactory.get_memory_controller(cgroup_v2)
     assert memory_controller.get_memory_limit() == 128
     assert memory_controller.get_usage_in_bytes() == 500
@@ -192,6 +195,6 @@ def test_cpuacct_controller(tmp_path_factory: TempPathFactory):
     cpuacct_usage = cpuacct_controller_dir / "cpuacct.usage"
     cpuacct_usage.write_text("128")
 
-    cgroup_v1 = CgroupCoreV1(cpuacct_controller_dir, tmp_dir)
+    cgroup_v1 = CgroupCoreV1(cpuacct_controller_dir, tmp_dir, Path("/"))
     cpuacct_controller = CpuAcctController(cgroup_v1)
     assert cpuacct_controller.get_cpu_time_ns() == 128


### PR DESCRIPTION
In a machine with Cgroups V1, by default Docker doesn't enter a cgroup namespace (`--cgroupns=host`).
Inside the container, as subtree of the host cgroup hierarchy is mounted:
```
# cat /proc/1/mountinfo
712 709 0:34 /docker/<guid> /sys/fs/cgroup/cpu,cpuacct ro,nosuid,nodev,noexec,relatime master:16 - cgroup cgroup rw,cpu,cpuacct
```
Meaning that accessing `/sys/fs/cgroup/<controller>/something` inside the container is the same as accessing `/sys/fs/cgroup/<controller>/docker/<guid>/something` from the host.

Reading from `/proc/pid/cgroup` yields a path in the **host** mount:
`3:cpu,cpuacct:/docker/<guid>`.
To  access this cgroup from within the container, we need to strtip the `/docker/<guid>` part.