### PR TITLE
cgroup v1 take into account mount root - bugfixes

### DIFF
--- a/granulate_utils/linux/cgroups_v2/cgroup.py
+++ b/granulate_utils/linux/cgroups_v2/cgroup.py
@@ -278,14 +278,6 @@ def _get_cgroup_mount_checked(controller: ControllerType) -> CgroupCore:
 
 def _get_cgroup_from_path(controller: ControllerType, cgroup_path_or_full_path: Path) -> CgroupCore:
     cgroup_mount = _get_cgroup_mount_checked(controller)
-
-    try:
-        # it's a real full path, has to be under cgroup_abs_path
-        cgroup_path_or_full_path = cgroup_path_or_full_path.relative_to(cgroup_mount.cgroup_abs_path)
-    except ValueError:
-        # it's a path relative to controller mount point
-        cgroup_path_or_full_path = Path(cgroup_path_or_full_path.as_posix().lstrip("/"))
-
     return cgroup_mount.with_new_path(cgroup_path_or_full_path)
 
 

--- a/granulate_utils/linux/cgroups_v2/cgroup.py
+++ b/granulate_utils/linux/cgroups_v2/cgroup.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import List, Literal, Mapping, Optional, Union
 
@@ -189,7 +188,6 @@ class CgroupCore:
            relative to the mount ROOT, which is / in most cases but /docker/guid in some containers.
            In these cases, we strip the mount ROOT and treat as a relative path under the mount path"""
 
-        logger = logging.getLogger("granulate")
         new_path = Path(new_path)
         if not new_path.is_absolute():
             normalized_path = self.cgroup_abs_path / new_path
@@ -198,7 +196,6 @@ class CgroupCore:
             try:
                 new_path.relative_to(self.cgroup_mount_path)  # no exception -> real absolute path
                 normalized_path = new_path
-                logger.debug(f"entering absolute cgroup path: {normalized_path}")
             except ValueError:
                 # Some paths resemble absolute paths, but they are not:
                 # /proc/pid/cgroup yields something the resembles an absolute path, but in reality it's relative
@@ -207,14 +204,13 @@ class CgroupCore:
                 # to create a relative path, then add it to the mount path
                 try:
                     normalized_path = self.cgroup_mount_path / new_path.relative_to(self.cgroup_mount_root)
-                    logger.debug(f"go /proc/pid/cgroup path: {new_path} normalized: {normalized_path}")
                 except ValueError:
-                    raise ValueError(f"new path {new_path} is not relative to cgroup mount root "
-                                     f"{self.cgroup_mount_root} or cgroup abs path {self.cgroup_abs_path}")
+                    raise ValueError(
+                        f"new path {new_path} is not relative to cgroup mount root "
+                        f"{self.cgroup_mount_root} or cgroup abs path {self.cgroup_abs_path}"
+                    )
 
-        new_cgroup = type(self)(normalized_path, self.cgroup_mount_path, self.cgroup_mount_root)
-        logger.debug(f"new cgroup full path is {new_cgroup.cgroup_abs_path}")
-        return new_cgroup
+        return type(self)(normalized_path, self.cgroup_mount_path, self.cgroup_mount_root)
 
 
 class CgroupCoreV1(CgroupCore):

--- a/granulate_utils/linux/cgroups_v2/cgroup.py
+++ b/granulate_utils/linux/cgroups_v2/cgroup.py
@@ -91,7 +91,7 @@ def _find_v1_hierarchies() -> Mapping[str, tuple[str, str]]:
         if controllers:
             hierarchy = mount.mount_point
             hierarchy = ns.resolve_host_root_links(hierarchy)
-            mount_root = ns.resolve_host_root_links(mount.root)
+            mount_root = mount.root
             for controller in controllers:
                 hierarchies[controller] = (hierarchy, mount_root)
     return hierarchies
@@ -110,7 +110,7 @@ def _find_v2_hierarchy() -> Optional[tuple[str, str]]:
         raise Exception("More than one cgroup2 mount found!")
     path = cgroup2_mounts[0].mount_point
     path = ns.resolve_host_root_links(path)
-    mount_root = ns.resolve_host_root_links(cgroup2_mounts[0].root)
+    mount_root = cgroup2_mounts[0].root
     return path, mount_root
 
 

--- a/tests/granulate_utils/test_cgroups.py
+++ b/tests/granulate_utils/test_cgroups.py
@@ -37,7 +37,7 @@ def test_get_cgroup_current_process():
 
     with patch(
         "granulate_utils.linux.cgroups_v2.cgroup._get_cgroup_mount",
-        return_value=CgroupCoreV1(root_path, Path("."), Path("/")),
+        return_value=CgroupCoreV1(root_path, root_path, Path("/")),
     ):
         with patch(
             "granulate_utils.linux.cgroups_v2.cgroup.read_proc_file",


### PR DESCRIPTION
Fix bugs introduced by the [original PR](https://github.com/Granulate/granulate-utils/pull/237)

`with_new_path` has to take care of both the absolute path case `/sys/fs/cgroup/....` and the looks-like-absolute-from-/proc/pid/cgroup-case `/docker/<guid>`.
We can't split into two functions because `get_cgroup_core(path)` is called externally with all kinds of paths

