### PR TITLE
cgroups: systemd controller manipulation

### DIFF
--- a/granulate_utils/linux/cgroups_v2/__init__.py
+++ b/granulate_utils/linux/cgroups_v2/__init__.py
@@ -19,3 +19,7 @@ from granulate_utils.linux.cgroups_v2.cgroup import get_process_cgroups  # noqa:
 from granulate_utils.linux.cgroups_v2.cpu_controller import CpuController, CpuControllerFactory  # noqa: F401
 from granulate_utils.linux.cgroups_v2.cpuacct_controller import CpuAcctController  # noqa: F401
 from granulate_utils.linux.cgroups_v2.memory_controller import MemoryController, MemoryControllerFactory  # noqa: F401
+from granulate_utils.linux.cgroups_v2.systemd_controller import (  # noqa: F401
+    SystemdLegacyController,
+    SystemdUnifiedController,
+)

--- a/granulate_utils/linux/cgroups_v2/cgroup.py
+++ b/granulate_utils/linux/cgroups_v2/cgroup.py
@@ -28,7 +28,7 @@ from granulate_utils.linux import ns
 from granulate_utils.linux.mountinfo import iter_mountinfo
 from granulate_utils.linux.process import read_proc_file
 
-ControllerType = Literal["memory", "cpu", "cpuacct"]
+ControllerType = Literal["memory", "cpu", "cpuacct", "name=systemd", ""]
 CONTROLLERS = {
     "blkio",
     "cpu",
@@ -43,6 +43,7 @@ CONTROLLERS = {
     "perf_event",
     "pids",
     "rdma",
+    "name=systemd",
 }
 
 CGROUP_V2_UNBOUNDED_VALUE = "max"
@@ -225,9 +226,15 @@ CGROUP_V2_DELEGATED_CONTROLLERS = "cgroup.subtree_control"
 
 class CgroupCoreV2(CgroupCore):
     def is_controller_supported(self, controller: ControllerType):
+        # Empty controller means we're interested just in the hierarchy
+        if controller == "":
+            return True
         return controller in self.read_from_interface_file(CGROUP_V2_SUPPORTED_CONTROLLERS).split()
 
     def is_controller_delegated(self, controller: ControllerType):
+        # Empty controller means we're interested just in the hierarchy
+        if controller == "":
+            return True
         return controller in self.read_from_interface_file(CGROUP_V2_DELEGATED_CONTROLLERS).split()
 
     @classmethod

--- a/granulate_utils/linux/cgroups_v2/systemd_controller.py
+++ b/granulate_utils/linux/cgroups_v2/systemd_controller.py
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+from typing import Optional, Union
+
+from psutil import Process
+
+from granulate_utils.linux.cgroups_v2.base_controller import BaseController
+from granulate_utils.linux.cgroups_v2.cgroup import CgroupCore, ControllerType
+
+
+class SystemdLegacyController(BaseController):
+    CONTROLLER: ControllerType = "name=systemd"
+
+    @classmethod
+    def get_cgroup_core(cls, cgroup: Optional[Union[Path, CgroupCore, Process]] = None) -> CgroupCore:
+        core = super().get_cgroup_core(cgroup)
+        assert core.is_v1, "Systemd controller should only be available in cgroups v1"
+        return core
+
+
+class SystemdUnifiedController(BaseController):
+    """Systemd controller for cgroups v2, which just represents the v2 hierarchy without any particular controller"""
+
+    CONTROLLER: ControllerType = ""
+
+    @classmethod
+    def get_cgroup_core(cls, cgroup: Optional[Union[Path, CgroupCore, Process]] = None) -> CgroupCore:
+        core = super().get_cgroup_core(cgroup)
+        assert core.is_v2, "Empty controller should only be available in cgroups v2"
+        return core


### PR DESCRIPTION
Add code to manipulate the Systemd cgroups hierarchy:.=
On Cgroups V1, manipulate the `name=systemd` controller.
On Cgroups V2, manipulate the cgroup hierarchy regardless of supported controllers (empty controller).

This is needed because Systemd keeps track of process assignment to units by their cgroups: if the V2 hierarchy is mounted, it acts as the source of truth - regardless of which controllers are enabled or delegated. If the V2 hierarchy is not mounted, a `name=systemd` controller is created to the V1 hierarchy and become the source of truth. 