### PR TITLE
Cgroup2: remove bogus assumptions about cgroup mounts

### DIFF
--- a/granulate_utils/linux/cgroups/cgroup.py
+++ b/granulate_utils/linux/cgroups/cgroup.py
@@ -79,12 +79,10 @@ def find_v2_hierarchy(resolve_host_root_links: bool = True) -> Optional[str]:
     Finds the mounted unified hierarchy for cgroup v2 controllers.
     """
     cgroup2_mounts = [
-        mount for mount in iter_mountinfo(1) if mount.filesystem_type == "cgroup2" and mount.mount_source == "cgroup2"
+        mount for mount in iter_mountinfo(1) if mount.filesystem_type == "cgroup2"
     ]
     if not cgroup2_mounts:
         return None
-    if len(cgroup2_mounts) > 1:
-        raise Exception("More than one cgroup2 mount found!")
     path = cgroup2_mounts[0].mount_point
     if resolve_host_root_links:
         path = ns.resolve_host_root_links(path)

--- a/granulate_utils/linux/cgroups_v2/cgroup.py
+++ b/granulate_utils/linux/cgroups_v2/cgroup.py
@@ -103,12 +103,10 @@ def _find_v2_hierarchy() -> Optional[tuple[str, str]]:
     Finds the mounted unified hierarchy for cgroup v2 controllers.
     """
     cgroup2_mounts = [
-        mount for mount in iter_mountinfo(1) if mount.filesystem_type == "cgroup2" and mount.mount_source == "cgroup2"
+        mount for mount in iter_mountinfo(1) if mount.filesystem_type == "cgroup2"
     ]
     if not cgroup2_mounts:
         return None
-    if len(cgroup2_mounts) > 1:
-        raise Exception("More than one cgroup2 mount found!")
     path = cgroup2_mounts[0].mount_point
     path = ns.resolve_host_root_links(path)
     mount_root = cgroup2_mounts[0].root


### PR DESCRIPTION
Cgroup2 detection used to look for a single mount point, that had been mounted as `mount -t cgroup2 *cgroup2* <path>` (without the `*`s).
In particular, there were two erroneous assumptions made: that the object being mount (in between `*` signs) is always called `cgroup2`, and that there might only be one cgroup2 mount present.
We've encountered case where neither of these assumptions held.

This commit removes them.