### PR TITLE
bigdata metadata from root ns

### DIFF
--- a/granulate_utils/metadata/bigdata/cloudera.py
+++ b/granulate_utils/metadata/bigdata/cloudera.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, List, Optional
 
+from ...linux.ns import resolve_host_root_links
+
 VERSION_KEY = "version="
 
 if TYPE_CHECKING:
@@ -11,7 +13,7 @@ else:
 
 def _get_agent_properties() -> Optional[List[str]]:
     try:
-        with open("/opt/cloudera/cm-agent/cm_version.properties", "r") as f:
+        with open(resolve_host_root_links("/opt/cloudera/cm-agent/cm_version.properties"), "r") as f:
             return f.readlines()
     except FileNotFoundError:
         pass

--- a/granulate_utils/metadata/bigdata/cloudera.py
+++ b/granulate_utils/metadata/bigdata/cloudera.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, List, Optional
 
-from ...linux.ns import resolve_host_root_links
+from granulate_utils.linux.ns import resolve_host_root_links
 
 VERSION_KEY = "version="
 

--- a/granulate_utils/metadata/bigdata/cloudera.py
+++ b/granulate_utils/metadata/bigdata/cloudera.py
@@ -15,7 +15,7 @@ def _get_agent_properties() -> Optional[List[str]]:
     try:
         with open(resolve_host_root_links("/opt/cloudera/cm-agent/cm_version.properties"), "r") as f:
             return f.readlines()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         pass
     return None
 

--- a/granulate_utils/metadata/bigdata/databricks.py
+++ b/granulate_utils/metadata/bigdata/databricks.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Optional, Union
 
+from ...linux.ns import resolve_host_root_links
+
 if TYPE_CHECKING:
     _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
 else:
@@ -9,7 +11,7 @@ else:
 
 def get_databricks_version() -> Optional[str]:
     try:
-        with open("/databricks/DBR_VERSION", "r") as f:
+        with open(resolve_host_root_links("/databricks/DBR_VERSION"), "r") as f:
             return f.read().strip()
     except FileNotFoundError:
         return None
@@ -17,7 +19,7 @@ def get_databricks_version() -> Optional[str]:
 
 def get_hadoop_version(logger: Optional[Union[logging.Logger, _LoggerAdapter]]) -> Optional[str]:
     try:
-        with open("/databricks/spark/HADOOP_VERSION", "r") as f:
+        with open(resolve_host_root_links("/databricks/spark/HADOOP_VERSION"), "r") as f:
             return f.read().strip()
     except FileNotFoundError:
         if logger:

--- a/granulate_utils/metadata/bigdata/databricks.py
+++ b/granulate_utils/metadata/bigdata/databricks.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Optional, Union
 
-from ...linux.ns import resolve_host_root_links
+from granulate_utils.linux.ns import resolve_host_root_links
 
 if TYPE_CHECKING:
     _LoggerAdapter = logging.LoggerAdapter[logging.Logger]

--- a/granulate_utils/metadata/bigdata/databricks.py
+++ b/granulate_utils/metadata/bigdata/databricks.py
@@ -13,7 +13,7 @@ def get_databricks_version() -> Optional[str]:
     try:
         with open(resolve_host_root_links("/databricks/DBR_VERSION"), "r") as f:
             return f.read().strip()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         return None
 
 
@@ -21,7 +21,7 @@ def get_hadoop_version(logger: Optional[Union[logging.Logger, _LoggerAdapter]]) 
     try:
         with open(resolve_host_root_links("/databricks/spark/HADOOP_VERSION"), "r") as f:
             return f.read().strip()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         if logger:
             logger.error("Failed to get hadoop version", exc_info=True)
     return None

--- a/granulate_utils/metadata/bigdata/dataproc.py
+++ b/granulate_utils/metadata/bigdata/dataproc.py
@@ -3,7 +3,7 @@ import subprocess
 from functools import partial
 from typing import TYPE_CHECKING, List, Optional, Union, cast
 
-from ...linux.ns import resolve_host_root_links, run_in_ns
+from granulate_utils.linux.ns import resolve_host_root_links, run_in_ns
 
 VERSION_KEY = "DATAPROC_IMAGE_VERSION="
 HADOOP_VERSION_CMD = "hadoop version"

--- a/granulate_utils/metadata/bigdata/dataproc.py
+++ b/granulate_utils/metadata/bigdata/dataproc.py
@@ -18,7 +18,7 @@ def _get_environment_info() -> Optional[List[str]]:
     try:
         with open(resolve_host_root_links("/etc/environment"), "r") as f:
             return f.readlines()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         pass
     return None
 

--- a/granulate_utils/metadata/bigdata/emr.py
+++ b/granulate_utils/metadata/bigdata/emr.py
@@ -16,7 +16,7 @@ def _get_instance_data() -> Optional[Dict[str, str]]:
             obj = json.loads(f.read())
             if isinstance(obj, dict):
                 return obj
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         pass
     return None
 

--- a/granulate_utils/metadata/bigdata/emr.py
+++ b/granulate_utils/metadata/bigdata/emr.py
@@ -2,7 +2,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from ...linux.ns import resolve_host_root_links
+from granulate_utils.linux.ns import resolve_host_root_links
 
 if TYPE_CHECKING:
     _LoggerAdapter = logging.LoggerAdapter[logging.Logger]

--- a/granulate_utils/metadata/bigdata/emr.py
+++ b/granulate_utils/metadata/bigdata/emr.py
@@ -2,6 +2,8 @@ import json
 import logging
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
+from ...linux.ns import resolve_host_root_links
+
 if TYPE_CHECKING:
     _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
 else:
@@ -10,7 +12,7 @@ else:
 
 def _get_instance_data() -> Optional[Dict[str, str]]:
     try:
-        with open("/mnt/var/lib/info/extraInstanceData.json", "r") as f:
+        with open(resolve_host_root_links("/proc/1/root/mnt/var/lib/info/extraInstanceData.json"), "r") as f:
             obj = json.loads(f.read())
             if isinstance(obj, dict):
                 return obj

--- a/granulate_utils/metadata/bigdata/emr.py
+++ b/granulate_utils/metadata/bigdata/emr.py
@@ -12,7 +12,7 @@ else:
 
 def _get_instance_data() -> Optional[Dict[str, str]]:
     try:
-        with open(resolve_host_root_links("/proc/1/root/mnt/var/lib/info/extraInstanceData.json"), "r") as f:
+        with open(resolve_host_root_links("/mnt/var/lib/info/extraInstanceData.json"), "r") as f:
             obj = json.loads(f.read())
             if isinstance(obj, dict):
                 return obj

--- a/lint.sh
+++ b/lint.sh
@@ -18,4 +18,4 @@ EXCLUDE_RE='.venv|venv|build|granulate_utils/generated'
 python3 -m isort --settings-path .isort.cfg $check_arg --skip granulate_utils/generated --skip venv --skip .venv --skip build .
 python3 -m black --line-length 120 $check_arg --exclude $EXCLUDE_RE .
 python3 -m flake8 --config .flake8  --exclude $(echo $EXCLUDE_RE | tr '|' ',') .
-python3 -m mypy --exclude $EXCLUDE_RE --python-version 3.9 .
+python3 -m mypy --exclude $EXCLUDE_RE .

--- a/lint.sh
+++ b/lint.sh
@@ -18,4 +18,4 @@ EXCLUDE_RE='.venv|venv|build|granulate_utils/generated'
 python3 -m isort --settings-path .isort.cfg $check_arg --skip granulate_utils/generated --skip venv --skip .venv --skip build .
 python3 -m black --line-length 120 $check_arg --exclude $EXCLUDE_RE .
 python3 -m flake8 --config .flake8  --exclude $(echo $EXCLUDE_RE | tr '|' ',') .
-python3 -m mypy --exclude $EXCLUDE_RE .
+python3 -m mypy --exclude $EXCLUDE_RE --python-version 3.9 .

--- a/tests/granulate_utils/test_bigdata.py
+++ b/tests/granulate_utils/test_bigdata.py
@@ -18,7 +18,7 @@ def test_detect_emr() -> None:
         mock_open(read_data=extra_instance_data_file_content),
     ) as mopen:
         assert get_bigdata_info() == BigDataInfo("emr", "emr-6.9.0")
-        mopen.assert_called_once_with("/mnt/var/lib/info/extraInstanceData.json", "r")
+        mopen.assert_called_once_with("/proc/1/root/mnt/var/lib/info/extraInstanceData.json", "r")
 
 
 def test_detect_databricks() -> None:
@@ -26,7 +26,7 @@ def test_detect_databricks() -> None:
 
     with patch("granulate_utils.metadata.bigdata.databricks.open", mock_open(read_data=version_file_content)) as mopen:
         assert get_bigdata_info() == BigDataInfo("databricks", "11.3")
-        mopen.assert_called_once_with("/databricks/DBR_VERSION", "r")
+        mopen.assert_called_once_with("/proc/1/root/databricks/DBR_VERSION", "r")
 
 
 def test_detect_dataproc() -> None:
@@ -40,7 +40,7 @@ DATAPROC_IMAGE_BUILD=20230208-155100-RC01-2_0_deb10_20230127_081410-RC01
         "granulate_utils.metadata.bigdata.dataproc.open", mock_open(read_data=environment_file_content)
     ) as mopen:
         assert get_bigdata_info() == BigDataInfo("dataproc", "2.0")
-        mopen.assert_called_once_with("/etc/environment", "r")
+        mopen.assert_called_once_with("/proc/1/root/etc/environment", "r")
 
 
 def test_detect_cloudera() -> None:
@@ -54,7 +54,7 @@ cloudera.hash=aa2740de2751a99075f3d170fd5e55fdfb4c6121
         "granulate_utils.metadata.bigdata.cloudera.open", mock_open(read_data=cm_agent_properties_file_content)
     ) as mopen:
         assert get_bigdata_info() == BigDataInfo("cloudera", "7.4.4")
-        mopen.assert_called_once_with("/opt/cloudera/cm-agent/cm_version.properties", "r")
+        mopen.assert_called_once_with("/proc/1/root/opt/cloudera/cm-agent/cm_version.properties", "r")
 
 
 def test_return_none() -> None:


### PR DESCRIPTION
Allow calling the bigdata metadata functions from a different mount namespace than init.