### PR TITLE
Added run_in_ns_wrapper to only run in namespace when root is detected.

### DIFF
--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -181,7 +181,7 @@ def _get_process_nspid_by_sched_files(process: Process) -> int:
         return None
 
     # We're searching `/proc`, so we only need to set our mount namespace
-    inner_pid = run_in_ns_wrapper(["mnt"], _find_inner_pid, process.pid)
+    inner_pid = run_in_ns(["mnt"], _find_inner_pid, process.pid)
     if inner_pid is not None:
         if not process.is_running():  # Make sure the pid wasn't reused for another process
             raise NoSuchProcess(process.pid)
@@ -274,11 +274,13 @@ def run_in_ns(
         return ret
 
 
-def is_this_root() -> bool:
+
+def is_root() -> bool:
     if sys.platform == "win32":
         return cast(int, ctypes.windll.shell32.IsUserAnAdmin()) == 1  # type: ignore
     else:
         return os.geteuid() == 0
+
 
 
 def run_in_ns_wrapper(
@@ -286,23 +288,10 @@ def run_in_ns_wrapper(
     callback: Callable[[], T],
     target_pid: int = 1,
 ) -> T:
-    if is_this_root():
+    if is_root():
         return run_in_ns(nstypes, callback, target_pid)
+    return callback()
 
-    ret: Union[T, _Sentinel] = _SENTINEL
-    exc: Optional[BaseException] = None
-
-    try:
-        ret = callback()
-    except BaseException as e:
-        exc = e
-
-    if isinstance(ret, _Sentinel):
-        assert exc is not None
-        raise exc
-    else:
-        assert exc is None
-        return ret
 
 
 def get_mnt_ns_ancestor(process: Process) -> Process:

--- a/granulate_utils/linux/ns.py
+++ b/granulate_utils/linux/ns.py
@@ -18,11 +18,11 @@ import ctypes
 import enum
 import os
 import re
-import sys
 from collections import deque
+from functools import lru_cache
 from pathlib import Path
 from threading import Thread
-from typing import Callable, Collection, List, Optional, TypeVar, Union, cast
+from typing import Callable, Collection, List, Optional, TypeVar, Union
 
 from psutil import NoSuchProcess, Process, process_iter
 
@@ -274,13 +274,9 @@ def run_in_ns(
         return ret
 
 
-
+@lru_cache(maxsize=None)
 def is_root() -> bool:
-    if sys.platform == "win32":
-        return cast(int, ctypes.windll.shell32.IsUserAnAdmin()) == 1  # type: ignore
-    else:
-        return os.geteuid() == 0
-
+    return os.geteuid() == 0
 
 
 def run_in_ns_wrapper(
@@ -291,7 +287,6 @@ def run_in_ns_wrapper(
     if is_root():
         return run_in_ns(nstypes, callback, target_pid)
     return callback()
-
 
 
 def get_mnt_ns_ancestor(process: Process) -> Process:

--- a/granulate_utils/linux/proc_events.py
+++ b/granulate_utils/linux/proc_events.py
@@ -269,7 +269,7 @@ def _ensure_thread_started(func: Callable):
             if _proc_events_listener is None:
                 try:
                     # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
-                    _proc_events_listener = ns.run_in_ns_wrapper(["net"], _start_listener)
+                    _proc_events_listener = ns.run_in_ns(["net"], _start_listener)
                 except Exception:
                     # TODO: We leak the pipe FDs here...
                     _proc_events_listener = None

--- a/granulate_utils/linux/proc_events.py
+++ b/granulate_utils/linux/proc_events.py
@@ -269,7 +269,7 @@ def _ensure_thread_started(func: Callable):
             if _proc_events_listener is None:
                 try:
                     # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
-                    _proc_events_listener = ns.run_in_ns(["net"], _start_listener)
+                    _proc_events_listener = ns.run_in_ns_wrapper(["net"], _start_listener)
                 except Exception:
                     # TODO: We leak the pipe FDs here...
                     _proc_events_listener = None

--- a/granulate_utils/metadata/cloud.py
+++ b/granulate_utils/metadata/cloud.py
@@ -26,7 +26,7 @@ from requests.exceptions import ConnectionError
 
 from granulate_utils.exceptions import BadResponseCode
 from granulate_utils.futures import call_in_parallel
-from granulate_utils.linux.ns import run_in_ns
+from granulate_utils.linux.ns import run_in_ns_wrapper
 from granulate_utils.metadata import Metadata
 
 METADATA_REQUEST_TIMEOUT = 5
@@ -229,7 +229,7 @@ def get_static_cloud_metadata(logger: Union[logging.LoggerAdapter, logging.Logge
         return None
 
     try:
-        metadata = run_in_ns(["net"], _fetch)
+        metadata = run_in_ns_wrapper(["net"], _fetch)
         if metadata is not None:
             return metadata
     except TimeoutError as exception:


### PR DESCRIPTION
This PR adds support for running gprofiler without root/sudo as discussed in issue 905 in the gprofiler repo: https://github.com/Granulate/gprofiler/issues/905. 

It creates run_in_ns_wrapper function which bypasses the code to enter name spaces when not root (as we assume we're always in the correct namespace for the processes being profiled). 

This commit is required for PR 936 in the gprofiler repo https://github.com/Granulate/gprofiler/pull/936.

I have tested this on x86 using scripts/build_x86_64_executable.sh script. Centos 9 Stream w/ kernel 6.6, though with some limitations mentioned in the gprofiler PR.

The code is linted.

One issue is when running on one system, I receive the below warning (though gprofiler completes and produces valid results)

> 	[2024-12-02 19:59:55,557] WARNING: gprofiler.profilers.java: Failed to enable proc_events listener for exited Java processes (this does not prevent Java profiling)
> 	Traceback (most recent call last):
> 	  File "granulate_utils/linux/proc_events.py", line 222, in start
> 	PermissionError: [Errno 1] Operation not permitted
> 	
> 	The above exception was the direct cause of the following exception:
> 	
> 	Traceback (most recent call last):
> 	  File "gprofiler/profilers/java.py", line 1395, in start
> 	    proc_events.register_exit_callback(self._proc_exit_callback)
> 	  File "granulate_utils/linux/proc_events.py", line 272, in wrapper
> 	  File "granulate_utils/linux/ns.py", line 305, in run_in_ns_wrapper
> 	  File "granulate_utils/linux/ns.py", line 299, in run_in_ns_wrapper
> 	  File "granulate_utils/linux/proc_events.py", line 260, in _start_listener
> 	  File "granulate_utils/linux/proc_events.py", line 225, in start
> PermissionError: This process doesn't have permissions to bind/connect to the process events connector

Issue seems to be that this bind call in the threading library requires root. Is this because the read we're trying to bind to is owned by root or does the function just inherently require root? I haven't been able to diagnose this.
https://github.com/Granulate/granulate-utils/blob/0cb9b70f4eda85f0a14e86ec41ecc7b57a133755/granulate_utils/linux/proc_events.py#L222